### PR TITLE
Fix [issue with a sample] link in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Here are the screens that make up SociaLite:
 
 ## Reporting Issues
 
-You can report an [issue with a sample](https://github.com/android/social-sample/issues) using
+You can report an [issue with a sample](https://github.com/android/socialite/issues) using
 this repository. When doing so, make sure to specify which sample you are referring to.
 
 ## Contributions


### PR DESCRIPTION
The current link to a [issue with a sample](https://github.com/android/social-sample/issues) in the [README.md file](https://github.com/android/socialite/blob/main/README.md) is not working. To fix this, I have updated the link to direct to the socialite issues tab. (https://github.com/android/socialite/issues)