### PR TITLE
Show preview of VideoEditScreen

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreen.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreen.kt
@@ -38,11 +38,11 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.VolumeMute
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DonutLarge
 import androidx.compose.material.icons.filled.FormatSize
 import androidx.compose.material.icons.filled.Movie
-import androidx.compose.material.icons.filled.VolumeMute
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -177,7 +177,7 @@ fun VideoEditScreen(
                     .padding(15.dp),
             ) {
                 VideoEditFilterChip(
-                    icon = Icons.Filled.VolumeMute,
+                    icon = Icons.AutoMirrored.Filled.VolumeMute,
                     selected = filterChipSelected,
                     onClick = onFilterChipPressed,
                     label = stringResource(id = R.string.remove_audio),

--- a/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreen.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreen.kt
@@ -332,7 +332,6 @@ fun TextOverlayOption(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun VideoEditFilterChip(
     icon: ImageVector,


### PR DESCRIPTION
# Issue

Current preview of VideoEditScreen can't be rendered due to initialization of viewmodel in screen composable function.

```Kotlin
    val viewModel: VideoEditScreenViewModel = hiltViewModel()
```

# Solution

I separate initialization logic to screen wrapper composable's input parameter. As I moved the ViewModel towards the input parameter of the Wrapper composable, I found that the state within the existing function also needed to be moved towards the wrapper.

## Changed

- Before

<img width="225" alt="스크린샷 2024-02-15 오후 7 07 39" src="https://github.com/android/socialite/assets/54518925/458e6df2-7481-4846-9db9-7e4bc54a9639">

- After
<img width="309" alt="스크린샷 2024-02-15 오후 7 07 59" src="https://github.com/android/socialite/assets/54518925/0bcd9e37-5d6f-40b0-a62c-34f9b950a1e1">
