### PR TITLE
Fix crash when launching BubbleActivity

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/BubbleActivity.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/BubbleActivity.kt
@@ -20,7 +20,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.google.android.samples.socialite.ui.Bubble
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class BubbleActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
```
java.lang.IllegalStateException: Given component holder class com.google.android.samples.socialite.BubbleActivity does not implement interface dagger.hilt.internal.GeneratedComponent or interface dagger.hilt.internal.GeneratedComponentManager
  at dagger.hilt.EntryPoints.get(EntryPoints.java:62)
  at dagger.hilt.android.internal.lifecycle.HiltViewModelFactory.createInternal(HiltViewModelFactory.java:149)
  at dagger.hilt.android.internal.lifecycle.HiltViewModelFactory.createInternal(HiltViewModelFactory.java:143)
  at androidx.hilt.navigation.HiltViewModelFactory.create(HiltNavBackStackEntry.kt:77)
  at androidx.hilt.navigation.compose.HiltViewModelKt.createHiltViewModelFactory(HiltViewModel.kt:57)
  at com.google.android.samples.socialite.ui.chat.ChatScreenKt.ChatScreen(ChatScreen.kt:531)
  at com.google.android.samples.socialite.ui.BubbleKt$Bubble$1.invoke(Bubble.kt:27)
  at com.google.android.samples.socialite.ui.BubbleKt$Bubble$1.invoke(Bubble.kt:26)
  at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:109)
  at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:35)
  at androidx.compose.runtime.CompositionLocalKt.CompositionLocalProvider(CompositionLocal.kt:248)
```