### PR TITLE
Use alwaysShowLabel in NavigationBarItem

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/Home.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/Home.kt
@@ -170,10 +170,9 @@ private fun HomeNavigationBar(
                     )
                 },
                 label = {
-                    if (selected) {
-                        Text(text = label)
-                    }
+                    Text(text = label)
                 },
+                alwaysShowLabel = false,
             )
         }
     }


### PR DESCRIPTION
Just like before, this shows the label only on the selected tab, but it comes with animation.

Change-Id: I14d50d2b587275ee9941b4ea7b20b505ecd78f71