### PR TITLE
Dark theme

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/ui/ContactRow.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/ContactRow.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/com/google/android/samples/socialite/ui/ContactRow.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/ContactRow.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -74,11 +75,13 @@ fun ChatRow(
             Text(
                 text = contact.name,
                 style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onBackground,
                 fontSize = 16.sp,
             )
             Text(
                 text = chat.chatWithLastMessage.text,
                 style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onBackground,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.padding(top = 4.dp),
@@ -92,6 +95,7 @@ fun ChatRow(
         ) {
             Text(
                 text = chat.chatWithLastMessage.timestamp.toReadableString(),
+                color = MaterialTheme.colorScheme.onBackground,
                 fontSize = 14.sp,
             )
         }

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/Timeline.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/Timeline.kt
@@ -283,7 +283,11 @@ fun MetadataOverlay(modifier: Modifier, mediaItem: TimelineMediaItem) {
                         .background(Color.LightGray),
                 )
             }
-            Text(modifier = Modifier.padding(end = 16.dp), text = mediaItem.chatName)
+            Text(
+                modifier = Modifier.padding(end = 16.dp),
+                text = mediaItem.chatName,
+                color = MaterialTheme.colorScheme.onBackground
+            )
         }
     }
 }
@@ -308,10 +312,12 @@ fun EmptyTimeline(
             text = stringResource(R.string.timeline_empty_title),
             modifier = Modifier.padding(top = 64.dp),
             style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onBackground
         )
         Text(
             text = stringResource(R.string.timeline_empty_message),
             textAlign = TextAlign.Center,
+            color = MaterialTheme.colorScheme.onBackground
         )
     }
 }

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2024 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <style name="Theme.Social" parent="android:Theme.Material.NoActionBar" />
+</resources>


### PR DESCRIPTION
Add dark theme to SociaLite. Before, the status bar icons would appear white on a light background in dark theme and some of the text would appear black on a dark background.

Showing new light and dark theme: https://photos.app.goo.gl/TB8TNbU8rbK5AZ268