### PR TITLE
Refine `StateFlow` usages

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/ui/camera/CameraViewModel.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/camera/CameraViewModel.kt
@@ -58,6 +58,8 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -71,7 +73,8 @@ class CameraViewModel @Inject constructor(
     private lateinit var extensionsManager: ExtensionsManager
 
     val chatId: Long? = savedStateHandle.get("chatId")
-    var viewFinderState = MutableStateFlow(ViewFinderState())
+    private val _viewFinderState = MutableStateFlow(ViewFinderState())
+    val viewFinderState: StateFlow<ViewFinderState> = _viewFinderState.asStateFlow()
 
     val aspectRatioStrategy =
         AspectRatioStrategy(AspectRatio.RATIO_16_9, AspectRatioStrategy.FALLBACK_RULE_NONE)
@@ -159,7 +162,7 @@ class CameraViewModel @Inject constructor(
                 activeCameraSelector,
                 useCaseGroupBuilder.build(),
             )
-            viewFinderState.value.cameraState = CameraState.READY
+            _viewFinderState.value.cameraState = CameraState.READY
         }
     }
 

--- a/app/src/main/java/com/google/android/samples/socialite/ui/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/chat/ChatViewModel.kt
@@ -25,6 +25,7 @@ import javax.inject.Inject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
@@ -72,7 +73,7 @@ class ChatViewModel @Inject constructor(
     }.stateInUi(emptyList())
 
     private val _input = MutableStateFlow("")
-    val input: StateFlow<String> = _input
+    val input: StateFlow<String> = _input.asStateFlow()
     private var inputPrefilled = false
 
     val sendEnabled = _input.map(::isInputValid).stateInUi(false)

--- a/app/src/main/java/com/google/android/samples/socialite/ui/player/VideoPlayerScreenViewModel.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/player/VideoPlayerScreenViewModel.kt
@@ -25,12 +25,13 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 class VideoPlayerScreenViewModel : ViewModel() {
 
     private val _player = MutableStateFlow<Player?>(null)
-    val player = _player.asStateFlow()
+    val player: StateFlow<Player?> = _player.asStateFlow()
     var shouldEnterPipMode by mutableStateOf(false)
 
     fun initializePlayer(uri: String, context: Context) {

--- a/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreenViewModel.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreenViewModel.kt
@@ -50,6 +50,7 @@ import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -62,10 +63,10 @@ class VideoEditScreenViewModel @Inject constructor(
     private var transformedVideoFilePath = ""
 
     private val _isFinishedEditing = MutableStateFlow(false)
-    val isFinishedEditing: StateFlow<Boolean> = _isFinishedEditing
+    val isFinishedEditing: StateFlow<Boolean> = _isFinishedEditing.asStateFlow()
 
     private val _isProcessing = MutableStateFlow(false)
-    val isProcessing: StateFlow<Boolean> = _isProcessing
+    val isProcessing: StateFlow<Boolean> = _isProcessing.asStateFlow()
 
     fun setChatId(chatId: Long) {
         this.chatId.value = chatId


### PR DESCRIPTION
- Convert `MutableStateFlow` to read-only state flows.
- Declare `StateFlow` types for public APIs.