### PR TITLE
modify predictive back in-app animation

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/ui/Main.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/Main.kt
@@ -83,7 +83,7 @@ fun MainNavigation(
         navController = navController,
         startDestination = "home",
         popEnterTransition = {
-            scaleIn(initialScale = 0.9F) + fadeIn()
+            scaleIn(initialScale = 1.1F) + fadeIn()
         },
         popExitTransition = {
             scaleOut(targetScale = 0.9F) + fadeOut()

--- a/app/src/main/java/com/google/android/samples/socialite/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/chat/ChatScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -141,7 +142,8 @@ fun ChatScreen(
             onCameraClick = onCameraClick,
             onPhotoPickerClick = onPhotoPickerClick,
             onVideoClick = onVideoClick,
-            modifier = modifier,
+            modifier = modifier
+                .clip(RoundedCornerShape(5)),
         )
     }
     LifecycleEffect(


### PR DESCRIPTION
Modify the predictive back in-app animation. [Video](https://photos.google.com/photo/AF1QipNgVbrA6XEl8jCJ0L9o424ik_c-5vFwdSa83iRt).

Is there a better way to ensure rounded corners while transitioning back? In this PR I've added 5% rounded corners to the entire ChatScreen.