### PR TITLE
Ensure notifications can show on the top of old devices' home screen

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/repository/NotificationHelper.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/repository/NotificationHelper.kt
@@ -267,6 +267,10 @@ class NotificationHelper @Inject constructor(@ApplicationContext context: Contex
             // notification.
             .setStyle(messagingStyle)
             .setWhen(messages.last().timestamp)
+            // Compat older APIs without notification channels for ensuring
+            // message notifications can show on the top of home screen.
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setDefaults(Notification.DEFAULT_ALL)
         // Don't sound/vibrate if an update to an existing notification.
         if (update) {
             builder.setOnlyAlertOnce(true)


### PR DESCRIPTION
> On platforms O and above this value is ignored in favor of the values set on the notification's channel. On older platforms, this value is still used, so it is still required for apps supporting those platforms.

See https://developer.android.com/reference/androidx/core/app/NotificationCompat.Builder#setDefaults(int).

| Before | After |
|--------|--------|
| <video src="https://github.com/android/socialite/assets/10363352/13bcdd68-3cbc-4f3b-b12a-fcf454fed8c7"> | <video src="https://github.com/android/socialite/assets/10363352/db524189-3305-4f1d-ad5c-8f7e8ec6814f"> |

