### PR TITLE
Refactor image loading from ContentProvider to IO thread

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/ui/IconPainter.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/IconPainter.kt
@@ -16,19 +16,34 @@
 
 package com.google.android.samples.socialite.ui
 
+import android.graphics.drawable.Drawable
 import android.net.Uri
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.graphics.drawable.IconCompat
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Creates and remembers a [Painter] from a bitmap icon specified by the [contentUri].
  */
 @Composable
 fun rememberIconPainter(contentUri: Uri): Painter {
-    val icon = IconCompat.createWithAdaptiveBitmapContentUri(contentUri)
     val context = LocalContext.current
-    return rememberDrawablePainter(drawable = icon.loadDrawable(context))
+
+    val loadDrawable by produceState<Drawable?>(
+        initialValue = null,
+        key1 = contentUri,
+    ) {
+        value = withContext(Dispatchers.IO) {
+            val icon = IconCompat.createWithAdaptiveBitmapContentUri(contentUri)
+            icon.loadDrawable(context)
+        }
+    }
+
+    return rememberDrawablePainter(drawable = loadDrawable)
 }


### PR DESCRIPTION
Moved the task of fetching Asset files from the ContentProvider from the MainThread to the IO thread

---

| before | after | 
| --- | --- |
|![스크린샷 2024-04-13 13 59 52](https://github.com/android/socialite/assets/38935359/cfedb5f8-adcb-4fe9-8c5b-9de66e2649d4) |![image](https://github.com/android/socialite/assets/38935359/42f322d1-b557-4702-a409-12497743e0c4)|

