### PR TITLE
Handle navigation back double clicks

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/ui/Main.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/Main.kt
@@ -116,7 +116,12 @@ fun MainNavigation(
             ChatScreen(
                 chatId = chatId,
                 foreground = true,
-                onBackPressed = { navController.popBackStack() },
+                onBackPressed = {
+                    if (!navController.popBackStack()) {
+                        // https://developer.android.com/guide/navigation/backstack#handle-failure
+                        activity.finish()
+                    }
+                },
                 onCameraClick = { navController.navigate("chat/$chatId/camera") },
                 onPhotoPickerClick = { navController.navigateToPhotoPicker(chatId) },
                 onVideoClick = { uri -> navController.navigate("videoPlayer?uri=$uri") },


### PR DESCRIPTION
Double-clicks the back button on Chat screen, and we can see the window goes to a white screen as the back stack is empty, we can handle the failed pop back ref to https://developer.android.com/guide/navigation/backstack#handle-failure


https://github.com/android/socialite/assets/10363352/cf802cee-893d-4b48-babf-833ba0fe4462

