### PR TITLE
Fix window insets on ChatScreen with safeContentPadding()

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/ui/Main.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/Main.kt
@@ -28,6 +28,7 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -121,7 +122,7 @@ fun MainNavigation(
                 onPhotoPickerClick = { navController.navigateToPhotoPicker(chatId) },
                 onVideoClick = { uri -> navController.navigate("videoPlayer?uri=$uri") },
                 prefilledText = text,
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier.fillMaxSize().safeContentPadding(),
             )
         }
         composable(

--- a/app/src/main/java/com/google/android/samples/socialite/ui/Main.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/Main.kt
@@ -122,7 +122,7 @@ fun MainNavigation(
                 onPhotoPickerClick = { navController.navigateToPhotoPicker(chatId) },
                 onVideoClick = { uri -> navController.navigate("videoPlayer?uri=$uri") },
                 prefilledText = text,
-                modifier = Modifier.fillMaxSize().safeContentPadding(),
+                modifier = Modifier.fillMaxSize(),
             )
         }
         composable(

--- a/app/src/main/java/com/google/android/samples/socialite/ui/Main.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/Main.kt
@@ -28,7 +28,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext

--- a/app/src/main/java/com/google/android/samples/socialite/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/chat/ChatScreen.kt
@@ -219,7 +219,7 @@ private fun ChatContent(
                 onSendClick = onSendClick,
                 onCameraClick = onCameraClick,
                 onPhotoPickerClick = onPhotoPickerClick,
-                contentPadding = PaddingValues(0.dp),
+                contentPadding = innerPadding.copy(layoutDirection, top = 0.dp),
                 sendEnabled = sendEnabled,
                 modifier = Modifier
                     .fillMaxWidth()


### PR DESCRIPTION
The issue is more visible with 3 button navigation. The InputBar is obscured by the navigation bar.
Modifier.safeContentPadding() ensures that the ChatScreen is not obscured.