### PR TITLE
Add preload manager to exoplayer to improve short form playback experience

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/data/utils/ShortsVideoList.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/data/utils/ShortsVideoList.kt
@@ -24,7 +24,7 @@ package com.google.android.samples.socialite.data.utils
 class ShortsVideoList {
     companion object {
         val mediaUris =
-          listOf(
+            listOf(
                 "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_1.mp4",
                 "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_2.mp4",
                 "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_3.mp4",

--- a/app/src/main/java/com/google/android/samples/socialite/data/utils/ShortsVideoList.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/data/utils/ShortsVideoList.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.samples.socialite.data.utils
+
+/**
+ *
+ * Sample list of short form video urls, used for preloading multiple videos in background especially used for enabling preload manager of exoplayer.
+ *
+ */
+class ShortsVideoList {
+    companion object {
+        val mediaUris =
+            mutableListOf(
+                "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_1.mp4",
+                "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_2.mp4",
+                "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_3.mp4",
+                "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_4.mp4",
+                "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_5.mp4",
+                "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_6.mp4",
+                "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_7.mp4",
+                "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_8.mp4",
+                "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_9.mp4",
+                "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_10.mp4",
+                "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_11.mp4",
+            )
+    }
+
+    fun get(index: Int): String {
+        return mediaUris[index.mod(mediaUris.size)]
+    }
+}

--- a/app/src/main/java/com/google/android/samples/socialite/data/utils/ShortsVideoList.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/data/utils/ShortsVideoList.kt
@@ -24,7 +24,7 @@ package com.google.android.samples.socialite.data.utils
 class ShortsVideoList {
     companion object {
         val mediaUris =
-            mutableListOf(
+          listOf(
                 "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_1.mp4",
                 "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_2.mp4",
                 "https://storage.googleapis.com/exoplayer-test-media-0/shorts_android_developers/shorts_3.mp4",

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/Timeline.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/Timeline.kt
@@ -154,7 +154,7 @@ fun TimelineVerticalPager(
                     .fillMaxSize()
                     .padding(8.dp)
                     .clip(RoundedCornerShape(16.dp))
-                  //  .background(MaterialTheme.colorScheme.secondaryContainer)
+                    .background(MaterialTheme.colorScheme.secondaryContainer)
                     .graphicsLayer {
                         // Calculate the absolute offset for the current page from the
                         // scroll position. We use the absolute value which allows us to mirror

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/Timeline.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/Timeline.kt
@@ -19,7 +19,6 @@ package com.google.android.samples.socialite.ui.home.timeline
 import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
-import androidx.compose.foundation.AndroidExternalSurface
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -28,7 +27,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -53,16 +51,20 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.ui.PlayerView
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.google.android.samples.socialite.R
@@ -71,6 +73,7 @@ import kotlin.math.absoluteValue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
+@androidx.annotation.OptIn(UnstableApi::class)
 @Composable
 fun Timeline(
     contentPadding: PaddingValues,
@@ -106,7 +109,7 @@ fun TimelineVerticalPager(
     player: Player?,
     onInitializePlayer: () -> Unit = {},
     onReleasePlayer: () -> Unit = {},
-    onChangePlayerItem: (uri: Uri?) -> Unit = {},
+    onChangePlayerItem: (uri: Uri?, page: Int) -> Unit = { uri: Uri?, i: Int -> },
     videoRatio: Float?,
 ) {
     val pagerState = rememberPagerState(pageCount = { mediaItems.count() })
@@ -114,9 +117,9 @@ fun TimelineVerticalPager(
         // Collect from the a snapshotFlow reading the settledPage
         snapshotFlow { pagerState.settledPage }.collect { page ->
             if (mediaItems[page].type == TimelineMediaType.VIDEO) {
-                onChangePlayerItem(Uri.parse(mediaItems[page].uri))
+                onChangePlayerItem(Uri.parse(mediaItems[page].uri), pagerState.currentPage)
             } else {
-                onChangePlayerItem(null)
+                onChangePlayerItem(null, pagerState.currentPage)
             }
         }
     }
@@ -200,23 +203,18 @@ fun TimelinePage(
     when (media.type) {
         TimelineMediaType.VIDEO -> {
             if (page == state.settledPage) {
-                // Use a default 1:1 ratio if the video size is unknown
-                val sanitizedRatio = videoRatio ?: 1f
-                AndroidExternalSurface(
-                    modifier = modifier
-                        .aspectRatio(sanitizedRatio, sanitizedRatio < 1f)
-                        .background(Color.White),
-                ) {
-                    onSurface { surface, _, _ ->
-                        player.setVideoSurface(surface)
-
-                        // Cleanup when surface is destroyed
-                        surface.onDestroyed {
-                            player.clearVideoSurface(this)
-                            release()
-                        }
-                    }
+                // When in preview, early return a Box with the received modifier preserving layout
+                if (LocalInspectionMode.current) {
+                    Box(modifier = modifier)
+                    return
                 }
+                AndroidView(
+                    factory = { PlayerView(it) },
+                    update = { playerView ->
+                        playerView.player = player
+                    },
+                    modifier = modifier.fillMaxSize(),
+                )
             }
         }
         TimelineMediaType.PHOTO -> {

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/Timeline.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/Timeline.kt
@@ -154,7 +154,7 @@ fun TimelineVerticalPager(
                     .fillMaxSize()
                     .padding(8.dp)
                     .clip(RoundedCornerShape(16.dp))
-                    .background(MaterialTheme.colorScheme.secondaryContainer)
+                  //  .background(MaterialTheme.colorScheme.secondaryContainer)
                     .graphicsLayer {
                         // Calculate the absolute offset for the current page from the
                         // scroll position. We use the absolute value which allows us to mirror

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/TimelineViewModel.kt
@@ -39,6 +39,7 @@ import com.google.android.samples.socialite.ui.player.preloadmanager.PreloadMana
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
+import kotlin.math.truncate
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
@@ -164,13 +165,15 @@ class TimelineViewModel @Inject constructor(
     }
 
     fun releasePlayer() {
-        player?.apply {
-            removeListener(videoSizeListener)
-            release()
-        }
         if (enablePreloadManager) {
             preloadManager.release()
         }
+        player?.apply {
+            removeListener(videoSizeListener)
+            removeListener(firstFrameListener)
+            release()
+        }
+        playerThread.quit()
         videoRatio = null
         player = null
     }

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/TimelineViewModel.kt
@@ -39,7 +39,6 @@ import com.google.android.samples.socialite.ui.player.preloadmanager.PreloadMana
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
-import kotlin.math.truncate
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/google/android/samples/socialite/ui/player/preloadmanager/PreloadManagerWrapper.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/player/preloadmanager/PreloadManagerWrapper.kt
@@ -57,10 +57,6 @@ private constructor(
 
     /** Builds a preload manager instance with default parameters. Preload manager should use the same looper and load control as the player */
     companion object {
-
-        // Thread on which the preload manager is running
-        private lateinit var playbackAndPreloadThread: Looper
-
         fun build(
             playbackLooper: Looper,
             loadControl: DefaultLoadControl,
@@ -69,7 +65,6 @@ private constructor(
             val trackSelector = DefaultTrackSelector(context)
             trackSelector.init({}, DefaultBandwidthMeter.getSingletonInstance(context))
             val renderersFactory = DefaultRenderersFactory(context)
-            playbackAndPreloadThread = playbackLooper
             val preloadManager = DefaultPreloadManager(
                 PreloadStatusControl(),
                 DefaultMediaSourceFactory(context),
@@ -117,9 +112,9 @@ private constructor(
                 addMediaItem(index = lastPreloadedIndex + i)
                 removeMediaItem()
             }
-            // With invalidate, preload manager will internally sort the priorities of all the media items added to it, and trigger the preload from the most important one
-            defaultPreloadManager.invalidate()
         }
+        // With invalidate, preload manager will internally sort the priorities of all the media items added to it, and trigger the preload from the most important one.
+        defaultPreloadManager.invalidate()
     }
 
     /** Remove media item from the preload window. */
@@ -153,7 +148,6 @@ private constructor(
         defaultPreloadManager.release()
         preloadWindow.clear()
         mediaItemsList.toMutableList().clear()
-        playbackAndPreloadThread.quit()
     }
 
     /** Retrieve the preloaded media source */

--- a/app/src/main/java/com/google/android/samples/socialite/ui/player/preloadmanager/PreloadManagerWrapper.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/player/preloadmanager/PreloadManagerWrapper.kt
@@ -34,7 +34,6 @@ import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import com.google.android.samples.socialite.ui.home.timeline.TimelineMediaItem
 
 /**
- * Created by Mayuri Khinvasara on 12/08/24.
  * Wrapper class to manage all functionalities of preload manager of exoplayer especially for short form content
  */
 @androidx.media3.common.util.UnstableApi
@@ -42,11 +41,15 @@ class PreloadManagerWrapper
 private constructor(
     private val defaultPreloadManager: DefaultPreloadManager,
 ) {
+    // Queue of media items to be preloaded. Can be ranked based on ranking data
     private val preloadWindow: ArrayDeque<Pair<MediaItem, Int>> = ArrayDeque()
 
-    // Default window size for preload manager
-    private var preloadWindowMaxSize = 6
+    // Default window size for preload manager. This defines how many maximum items will be preloaded at a time. If more than maximum items are added to the preload window
+    private var preloadWindowMaxSize = 5
+
     private var currentPlayingIndex = C.INDEX_UNSET
+
+    // List of all items in our current list of media items to be rendered on the UI
     private var mediaItemsList = listOf<TimelineMediaItem>()
 
     // Defines when to start preloading next items w.r.t current playing item

--- a/app/src/main/java/com/google/android/samples/socialite/ui/player/preloadmanager/PreloadManagerWrapper.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/player/preloadmanager/PreloadManagerWrapper.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.samples.socialite.ui.player.preloadmanager
+
+import android.content.Context
+import android.os.Looper
+import androidx.annotation.MainThread
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.exoplayer.DefaultRendererCapabilitiesList
+import androidx.media3.exoplayer.DefaultRenderersFactory
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.source.preload.DefaultPreloadManager
+import androidx.media3.exoplayer.source.preload.DefaultPreloadManager.Status.STAGE_LOADED_TO_POSITION_MS
+import androidx.media3.exoplayer.source.preload.TargetPreloadStatusControl
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
+import com.google.android.samples.socialite.ui.home.timeline.TimelineMediaItem
+import com.google.android.samples.socialite.ui.home.timeline.TimelineMediaType
+
+/**
+ * Created by Mayuri Khinvasara on 12/08/24.
+ * Wrapper class to manage all functionalities of preload manager of exoplayer especially for short form content
+ */
+@androidx.media3.common.util.UnstableApi
+class PreloadManagerWrapper
+private constructor(
+    private val defaultPreloadManager: DefaultPreloadManager,
+) {
+    private val preloadWindow: ArrayDeque<Pair<MediaItem, Int>> = ArrayDeque()
+
+    // Default window size for preload manager
+    private var preloadWindowSize = 5
+
+    /** Builds a preload manager instance with default parameters. Preload manager should use the same looper and load control as the player */
+    companion object {
+        fun build(
+            playbackLooper: Looper,
+            loadControl: DefaultLoadControl,
+            context: Context,
+        ): PreloadManagerWrapper {
+            val trackSelector = DefaultTrackSelector(context)
+            trackSelector.init({}, DefaultBandwidthMeter.getSingletonInstance(context))
+            val renderersFactory = DefaultRenderersFactory(context)
+            val preloadManager = DefaultPreloadManager(
+                PreloadStatusControl(),
+                DefaultMediaSourceFactory(context),
+                trackSelector,
+                DefaultBandwidthMeter.getSingletonInstance(context),
+                DefaultRendererCapabilitiesList.Factory(renderersFactory),
+                loadControl.allocator,
+                playbackLooper,
+            )
+            return PreloadManagerWrapper(preloadManager)
+        }
+    }
+
+    /** Add initial list of videos to the preload manager. */
+    fun init(mediaList: List<TimelineMediaItem>) {
+        for ((index, item) in mediaList.withIndex()) {
+            if (item.type == TimelineMediaType.VIDEO) {
+                addMediaItem((MediaItem.fromUri(item.uri)), index)
+            }
+        }
+    }
+
+    /** Sets the index of the current playing media. */
+    fun setCurrentPlayingIndex(currentPlayingIndex: Int) {
+        defaultPreloadManager.setCurrentPlayingIndex(currentPlayingIndex)
+    }
+
+    /** Sets the size of the Preload Queue. */
+    fun setPreloadWindowSize(preloadWindowSize1: Int) {
+        preloadWindowSize = preloadWindowSize1
+    }
+
+    /** Add media item to the preload manager */
+    fun addMediaItem(mediaItem: MediaItem, index: Int): Boolean {
+        // item not found in list. This could happen if the list is auto purged or contents refreshed by APIs
+        if (index < 0) {
+            return false
+        }
+        // item already added , avoid duplicates
+        if (preloadWindow.contains(Pair(mediaItem, index))) {
+            return false
+        }
+
+        // Window full, purge old data added at the start of the queue
+        if (preloadWindow.size >= preloadWindowSize) {
+            defaultPreloadManager.remove(preloadWindow.first().first)
+            preloadWindow.removeFirstOrNull()
+        }
+        // Add video to preload list
+        preloadWindow.add(Pair(mediaItem, index))
+        defaultPreloadManager.add(mediaItem, index)
+        defaultPreloadManager.invalidate()
+        return true
+    }
+
+    /** Releases the preload manager. This must be called on the main thread */
+    @MainThread
+    fun release() {
+        defaultPreloadManager.release()
+    }
+
+    /** Customize time to preload, by default as per ranking data */
+    @androidx.media3.common.util.UnstableApi
+    class PreloadStatusControl : TargetPreloadStatusControl<Int> {
+        override fun getTargetPreloadStatus(rankingData: Int): DefaultPreloadManager.Status {
+            // By default preload first 5 seconds of the video
+            return DefaultPreloadManager.Status(STAGE_LOADED_TO_POSITION_MS, 5000L)
+        }
+    }
+}


### PR DESCRIPTION
Add preload manager to exoplayer to improve short form playback experience

 (1) Add preload manager for exoplayer (2) Create an Wrapper class to manage and customize all functionalities of preload (PreloadManagerWrapper)(3) Add preload manager as an optional to Timeline screen (4) Add 10 remote videos to chats by sending :preload: message to any chat (5) Replace Timeline surface view with Player view for better performance.
 
 In order to test / generate a bunch of short form videos in the Timeline View, send a "preload" text message to any chat in the Chat screen. Thereby a list of 10 short videos urls (listed in ShortsVideoList class) will be sent as a response. These vidoes can then be used in the Timeline View to scroll .