### PR TITLE
Fix: Crash on opening BubbleActivity 

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/BubbleActivity.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/BubbleActivity.kt
@@ -20,7 +20,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.google.android.samples.socialite.ui.Bubble
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class BubbleActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
This PR resolves the crash that occurs when opening BubbleActivity. 
The issue was caused by the missing ```@AndroidEntryPoint``` annotation on the BubbleActivity class, which is essential for integrating Dagger Hilt dependency injection.