### PR TITLE
Add triggers to .github/workflows/

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Pull Request
 
 on:
   workflow_dispatch:
+  push:
+    branches: [ main ]
   pull_request:
     types: [ opened, synchronize, reopened ]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Pull Request
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [ opened, synchronize, reopened ]
 


### PR DESCRIPTION
This PR standardizes GitHub Actions triggers in workflow files within `.github/workflows/`.

The goal is to ensure workflows run consistently on `push`, `pull_request`, and `workflow_dispatch` events where appropriate.

This is part of a batch of pull requests across repositories owned by the `android` organization on GitHub.

**Project Owner:** Please review the changes carefully to ensure they are correct and appropriate for this project before approving and merging.

* If you do not think this change is appropriate (e.g., a workflow should NOT run on one of these triggers), please leave a comment explaining why.
* If you think the goal is appropriate but notice a mistake in the implementation, please leave a comment detailing the mistake.
