### PR TITLE
Fix the pane transition issue on the ChatListDetails screen

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/ChatsListDetail.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/ChatsListDetail.kt
@@ -64,7 +64,7 @@ fun ChatsListDetail(
 
     LaunchedEffect(LocalConfiguration.current) {
         val currentDestination = navigator.currentDestination
-        if(currentDestination != null) {
+        if (currentDestination != null) {
             navigator.navigateTo(currentDestination.pane, currentDestination.contentKey)
         }
     }

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/ChatsListDetail.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/ChatsListDetail.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.navigation.NavHostController
 import com.google.android.samples.socialite.AppArgs
 import com.google.android.samples.socialite.ui.chat.ChatScreen
@@ -58,6 +59,13 @@ fun ChatsListDetail(
                 pane = ListDetailPaneScaffoldRole.Detail,
                 contentKey = chatId,
             )
+        }
+    }
+
+    LaunchedEffect(LocalConfiguration.current) {
+        val currentDestination = navigator.currentDestination
+        if(currentDestination != null) {
+            navigator.navigateTo(currentDestination.pane, currentDestination.contentKey)
         }
     }
 


### PR DESCRIPTION
This PR fixes a pane transition issue on the ChatListDetails screen.  The screen is expected to switch single pane layout and two pane layout according to the available horizontal space, while it does not actually. 