### PR TITLE
Fix: self-letterboxing on the timeline screen.

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/chat/ChatScreen.kt
@@ -16,13 +16,10 @@
 
 package com.google.android.samples.socialite.ui.chat
 
-import android.graphics.Bitmap
-import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
@@ -30,7 +27,6 @@ import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -59,7 +55,6 @@ import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.PhotoLibrary
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.Icon
@@ -79,7 +74,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -88,10 +82,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.onKeyEvent
@@ -108,7 +99,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -121,11 +111,11 @@ import com.google.android.samples.socialite.model.ChatDetail
 import com.google.android.samples.socialite.model.Contact
 import com.google.android.samples.socialite.ui.SocialTheme
 import com.google.android.samples.socialite.ui.chat.component.isKeyPressed
+import com.google.android.samples.socialite.ui.components.PlayArrowIcon
+import com.google.android.samples.socialite.ui.components.VideoPreview
 import com.google.android.samples.socialite.ui.rememberIconPainter
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val TAG = "ChatUI"
 
@@ -499,47 +489,19 @@ private fun VideoMessagePreview(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current.applicationContext
-
-    // Running on an IO thread for loading metadata from remote urls to reduce lag time
-    val bitmapState = produceState<Bitmap?>(initialValue = null) {
-        withContext(Dispatchers.IO) {
-            val mediaMetadataRetriever = MediaMetadataRetriever()
-
-            // Remote url
-            if (videoUri.contains("https://")) {
-                mediaMetadataRetriever.setDataSource(videoUri, HashMap<String, String>())
-            } else { // Locally saved files
-                mediaMetadataRetriever.setDataSource(context, videoUri.toUri())
-            }
-            // Return any frame that the framework considers representative of a valid frame
-            value = mediaMetadataRetriever.frameAtTime
-        }
-    }
-
-    bitmapState.value?.let { bitmap ->
-        Box(
-            modifier = modifier
-                .clickable(onClick = onClick)
-                .padding(10.dp),
-        ) {
-            Image(
-                bitmap = bitmap.asImageBitmap(),
-                contentDescription = null,
-                colorFilter = ColorFilter.tint(Color.Gray, BlendMode.Darken),
-            )
-
-            Icon(
-                Icons.Filled.PlayArrow,
-                tint = Color.White,
-                contentDescription = null,
+    VideoPreview(
+        videoUri = videoUri,
+        modifier = modifier
+            .clickable(onClick = onClick)
+            .padding(10.dp),
+        overlay = {
+            PlayArrowIcon(
                 modifier = Modifier
                     .size(50.dp)
-                    .align(Alignment.Center)
-                    .border(3.dp, Color.White, shape = CircleShape),
+                    .align(Alignment.Center),
             )
-        }
-    }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/google/android/samples/socialite/ui/components/Icon.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/components/Icon.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.samples.socialite.ui.components
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun PlayArrowIcon(
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    tint: Color = Color.Companion.White,
+) {
+    val minSize = LocalMinimumInteractiveComponentSize.current
+    Icon(
+        Icons.Filled.PlayArrow,
+        tint = tint,
+        contentDescription = contentDescription,
+        modifier = modifier
+            .sizeIn(minWidth = minSize, minHeight = minSize)
+            .border(3.dp, Color.Companion.White, shape = CircleShape),
+    )
+}

--- a/app/src/main/java/com/google/android/samples/socialite/ui/components/VideoPreview.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/components/VideoPreview.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.samples.socialite.ui.components
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.media.MediaMetadataRetriever
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.net.toUri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+internal fun VideoPreview(
+    videoUri: String,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Companion.Fit,
+    contentDescription: String? = null,
+    colorFilter: ColorFilter = ColorFilter.Companion.tint(Color.Companion.Gray, BlendMode.Companion.Darken),
+    overlay: @Composable (BoxScope.() -> Unit)? = null,
+) {
+    when (overlay) {
+        null -> VideoPreview(
+            state = rememberVideoPreviewBitmap(videoUri),
+            modifier = modifier,
+            contentScale = contentScale,
+            contentDescription = contentDescription,
+            colorFilter = colorFilter,
+        )
+        else -> {
+            VideoPreview(
+                state = rememberVideoPreviewBitmap(videoUri),
+                overlay = overlay,
+                modifier = modifier,
+                contentScale = contentScale,
+                contentDescription = contentDescription,
+                colorFilter = colorFilter,
+            )
+        }
+    }
+}
+
+@Composable
+private fun VideoPreview(
+    state: State<Bitmap?>,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Companion.Fit,
+    contentDescription: String? = null,
+    colorFilter: ColorFilter = ColorFilter.Companion.tint(Color.Companion.Gray, BlendMode.Companion.Darken),
+) {
+    val bitmap = state.value
+    if (bitmap != null) {
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = contentDescription,
+            colorFilter = colorFilter,
+            contentScale = contentScale,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+private fun VideoPreview(
+    state: State<Bitmap?>,
+    overlay: @Composable BoxScope.() -> Unit,
+    modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Companion.Fit,
+    contentDescription: String? = null,
+    colorFilter: ColorFilter = ColorFilter.Companion.tint(Color.Companion.Gray, BlendMode.Companion.Darken),
+) {
+    val bitmap = state.value
+    if (bitmap != null) {
+        Box(
+            modifier = modifier,
+        ) {
+            Image(
+                bitmap = bitmap.asImageBitmap(),
+                contentDescription = contentDescription,
+                colorFilter = colorFilter,
+                contentScale = contentScale,
+            )
+            overlay()
+        }
+    }
+}
+
+private suspend fun createVideoPreviewBitmap(videoUri: String, context: Context): Bitmap? {
+    return withContext(Dispatchers.IO) {
+        val mediaMetadataRetriever = MediaMetadataRetriever()
+
+        // Remote url
+        if (videoUri.contains("https://")) {
+            mediaMetadataRetriever.setDataSource(videoUri, HashMap<String, String>())
+        } else { // Locally saved files
+            mediaMetadataRetriever.setDataSource(context, videoUri.toUri())
+        }
+        // Return any frame that the framework considers representative of a valid frame
+        mediaMetadataRetriever.frameAtTime
+    }
+}
+
+@Composable
+private fun rememberVideoPreviewBitmap(videoUri: String): State<Bitmap?> {
+    val context = LocalContext.current
+    val state = remember(videoUri) {
+        val state = mutableStateOf<Bitmap?>(null)
+        state
+    }.also {
+        LaunchedEffect(videoUri) {
+            it.value = createVideoPreviewBitmap(videoUri, context)
+        }
+    }
+    return state
+}

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/Timeline.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/Timeline.kt
@@ -16,124 +16,70 @@
 
 package com.google.android.samples.socialite.ui.home.timeline
 
-import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.pager.PagerState
-import androidx.compose.foundation.pager.VerticalPager
-import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.lerp
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.LifecycleStartEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.ui.PlayerView
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
-import com.google.android.samples.socialite.R
-import com.google.android.samples.socialite.ui.home.HomeAppBar
-import com.google.android.samples.socialite.ui.home.HomeBackground
-import com.google.android.samples.socialite.ui.navigation.TopLevelDestination
-import com.google.android.samples.socialite.ui.rememberIconPainter
-import kotlin.math.absoluteValue
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import com.google.android.samples.socialite.ui.home.timeline.component.EmptyTimeline
+import com.google.android.samples.socialite.ui.home.timeline.component.TimelineFormat
+import com.google.android.samples.socialite.ui.home.timeline.component.TimelineGrid
+import com.google.android.samples.socialite.ui.home.timeline.component.TimelineScaffold
+import com.google.android.samples.socialite.ui.home.timeline.component.TimelineVerticalPager
+import com.google.android.samples.socialite.ui.home.timeline.component.rememberTimelineFormat
 
 @androidx.annotation.OptIn(UnstableApi::class)
 @Composable
 fun Timeline(
     modifier: Modifier = Modifier,
+    viewModel: TimelineViewModel = hiltViewModel(),
+    format: TimelineFormat = rememberTimelineFormat(),
 ) {
-    val viewModel: TimelineViewModel = hiltViewModel()
-    val media = viewModel.media
+    val mediaItems by viewModel.media.collectAsStateWithLifecycle(emptyList())
+
     val player = viewModel.player
     val videoRatio = viewModel.videoRatio
-    Scaffold(
-        modifier = modifier,
-        topBar = {
-            HomeAppBar(title = stringResource(TopLevelDestination.Timeline.label))
-        },
-    ) { contentPadding ->
-        HomeBackground(modifier = Modifier.fillMaxSize())
-        if (media.isEmpty()) {
-            EmptyTimeline(contentPadding, modifier)
-        } else {
-            TimelineVerticalPager(
-                contentPadding,
-                Modifier,
-                media,
-                player,
-                viewModel::initializePlayer,
-                viewModel::releasePlayer,
-                viewModel::changePlayerItem,
-                videoRatio,
+
+    when {
+        mediaItems.isEmpty() -> {
+            TimelineScaffold(modifier = modifier) { contentPadding ->
+                EmptyTimeline(contentPadding, modifier)
+            }
+        }
+        else -> {
+            Timeline(
+                player = player,
+                mediaItems = mediaItems,
+                videoRatio = videoRatio,
+                onChangePlayerItem = viewModel::changePlayerItem,
+                onInitializePlayer = viewModel::initializePlayer,
+                onReleasePlayer = viewModel::releasePlayer,
+                format = format,
             )
         }
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun TimelineVerticalPager(
-    contentPadding: PaddingValues,
-    modifier: Modifier = Modifier,
+fun Timeline(
     mediaItems: List<TimelineMediaItem>,
     player: Player?,
+    videoRatio: Float?,
+    modifier: Modifier = Modifier,
+    format: TimelineFormat = rememberTimelineFormat(),
+    onChangePlayerItem: (uri: Uri?, page: Int) -> Unit = { uri: Uri?, i: Int -> },
     onInitializePlayer: () -> Unit = {},
     onReleasePlayer: () -> Unit = {},
-    onChangePlayerItem: (uri: Uri?, page: Int) -> Unit = { uri: Uri?, i: Int -> },
-    videoRatio: Float?,
 ) {
-    val pagerState = rememberPagerState(pageCount = { mediaItems.count() })
-    LaunchedEffect(pagerState) {
-        // Collect from the a snapshotFlow reading the settledPage
-        snapshotFlow { pagerState.settledPage }.collect { page ->
-            if (mediaItems[page].type == TimelineMediaType.VIDEO) {
-                onChangePlayerItem(Uri.parse(mediaItems[page].uri), pagerState.currentPage)
-            } else {
-                onChangePlayerItem(null, pagerState.currentPage)
-            }
-        }
-    }
-
     val currentOnInitializePlayer by rememberUpdatedState(onInitializePlayer)
     val currentOnReleasePlayer by rememberUpdatedState(onReleasePlayer)
     if (Build.VERSION.SDK_INT > 23) {
@@ -152,186 +98,26 @@ fun TimelineVerticalPager(
         }
     }
 
-    VerticalPager(
-        state = pagerState,
-        modifier = modifier
-            .padding(contentPadding)
-            .fillMaxSize(),
-    ) { page ->
-        if (player != null) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(8.dp)
-                    .clip(RoundedCornerShape(16.dp))
-                    .background(MaterialTheme.colorScheme.secondaryContainer)
-                    .graphicsLayer {
-                        // Calculate the absolute offset for the current page from the
-                        // scroll position. We use the absolute value which allows us to mirror
-                        // any effects for both directions
-                        val pageOffset = (
-                            (pagerState.currentPage - page) + pagerState
-                                .currentPageOffsetFraction
-                            ).absoluteValue
-
-                        // We animate the alpha, between 0% and 100%
-                        alpha = lerp(
-                            start = 0f,
-                            stop = 1f,
-                            fraction = 1f - pageOffset.coerceIn(0f, 1f),
-                        )
-                    },
-            ) {
-                TimelinePage(
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .padding(8.dp)
-                        .clip(RoundedCornerShape(8.dp)),
-                    media = mediaItems[page],
+    when (format) {
+        TimelineFormat.Pager -> {
+            TimelineScaffold(modifier = modifier) { contentPadding ->
+                TimelineVerticalPager(
+                    mediaItems = mediaItems,
                     player = player,
-                    page,
-                    pagerState,
-                    videoRatio,
-                )
-
-                MetadataOverlay(modifier = Modifier.padding(16.dp), mediaItem = mediaItems[page])
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-fun TimelinePage(
-    modifier: Modifier = Modifier,
-    media: TimelineMediaItem,
-    player: Player,
-    page: Int,
-    state: PagerState,
-    videoRatio: Float?,
-) {
-    when (media.type) {
-        TimelineMediaType.VIDEO -> {
-            if (page == state.settledPage) {
-                // When in preview, early return a Box with the received modifier preserving layout
-                if (LocalInspectionMode.current) {
-                    Box(modifier = modifier)
-                    return
-                }
-                AndroidView(
-                    factory = { PlayerView(it) },
-                    update = { playerView ->
-                        playerView.player = player
-                    },
-                    modifier = modifier.fillMaxSize(),
+                    videoRatio = videoRatio,
+                    onChangePlayerItem = onChangePlayerItem,
+                    modifier = Modifier.fillMaxSize().padding(contentPadding),
                 )
             }
         }
-        TimelineMediaType.PHOTO -> {
-            AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(media.uri)
-                    .build(),
-                contentDescription = null,
-                modifier = modifier
-                    .fillMaxSize(),
-                contentScale = ContentScale.Fit,
+
+        TimelineFormat.Grid -> {
+            TimelineGrid(
+                mediaItems = mediaItems,
+                player = player,
+                onChangePlayerItem = onChangePlayerItem,
+                modifier = modifier,
             )
         }
-    }
-}
-
-@Composable
-fun MetadataOverlay(modifier: Modifier, mediaItem: TimelineMediaItem) {
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .zIndex(999f),
-    ) {
-        if (mediaItem.type == TimelineMediaType.VIDEO) {
-            val mediaMetadataRetriever = MediaMetadataRetriever()
-            val context = LocalContext.current.applicationContext
-
-            // Running on an IO thread for loading metadata from remote urls to reduce lag time
-            val duration: State<Long?> = produceState<Long?>(initialValue = null) {
-                withContext(Dispatchers.IO) {
-                    // Remote url
-                    if (mediaItem.uri.contains("https://")) {
-                        mediaMetadataRetriever.setDataSource(mediaItem.uri, HashMap<String, String>())
-                    } else { // Locally saved files
-                        mediaMetadataRetriever.setDataSource(context, Uri.parse(mediaItem.uri))
-                    }
-                    value =
-                        mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
-                            ?.toLong()
-                }
-            }
-            duration.value?.let {
-                val seconds = it / 1000L
-                val minutes = seconds / 60L
-                Box(
-                    modifier = Modifier
-                        .padding(16.dp)
-                        .align(Alignment.TopEnd)
-                        .clip(RoundedCornerShape(50))
-                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)),
-                ) {
-                    Text(
-                        modifier = Modifier.padding(8.dp),
-                        text = "%d:%02d".format(minutes, seconds % 60),
-                    )
-                }
-            }
-        }
-
-        Row(
-            modifier = Modifier
-                .padding(16.dp)
-                .align(Alignment.BottomStart)
-                .clip(RoundedCornerShape(50))
-                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            mediaItem.chatIconUri?.let {
-                Image(
-                    painter = rememberIconPainter(contentUri = it),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .size(48.dp)
-                        .clip(CircleShape)
-                        .background(Color.LightGray),
-                )
-            }
-            Text(modifier = Modifier.padding(end = 16.dp), text = mediaItem.chatName)
-        }
-    }
-}
-
-@Composable
-fun EmptyTimeline(
-    contentPadding: PaddingValues,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier
-            .padding(contentPadding)
-            .padding(64.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Image(
-            painter = painterResource(id = R.drawable.empty_timeline),
-            contentDescription = null,
-        )
-        Text(
-            text = stringResource(R.string.timeline_empty_title),
-            modifier = Modifier.padding(top = 64.dp),
-            style = MaterialTheme.typography.titleLarge,
-        )
-        Text(
-            text = stringResource(R.string.timeline_empty_message),
-            textAlign = TextAlign.Center,
-        )
     }
 }

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/TimelineViewModel.kt
@@ -26,7 +26,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
@@ -34,13 +33,18 @@ import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
+import com.google.android.samples.socialite.model.ChatDetail
 import com.google.android.samples.socialite.repository.ChatRepository
 import com.google.android.samples.socialite.ui.player.preloadmanager.PreloadManagerWrapper
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flattenConcat
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 
 @UnstableApi
 @HiltViewModel
@@ -48,9 +52,6 @@ class TimelineViewModel @Inject constructor(
     @ApplicationContext private val application: Context,
     private val repository: ChatRepository,
 ) : ViewModel() {
-    // List of videos and photos from chats
-    var media by mutableStateOf<List<TimelineMediaItem>>(emptyList())
-
     // Single player instance - in the future, we can implement a pool of players to improve
     // latency and allow for concurrent playback
     var player by mutableStateOf<ExoPlayer?>(null)
@@ -87,30 +88,41 @@ class TimelineViewModel @Inject constructor(
         }
     }
 
-    init {
-        viewModelScope.launch {
-            val allChats = repository.getChats().first()
-            val newList = mutableListOf<TimelineMediaItem>()
-            for (chatDetail in allChats) {
-                val messages = repository.findMessages(chatDetail.chatWithLastMessage.id).first()
-                for (message in messages) {
-                    if (message.mediaUri != null) {
-                        newList += TimelineMediaItem(
-                            uri = message.mediaUri,
-                            type = if (message.mediaMimeType?.contains("video") == true) {
-                                TimelineMediaType.VIDEO
-                            } else {
-                                TimelineMediaType.PHOTO
-                            },
-                            timestamp = message.timestamp,
-                            chatName = chatDetail.firstContact.name,
-                            chatIconUri = chatDetail.firstContact.iconUri,
-                        )
-                    }
-                }
+    @kotlin.OptIn(ExperimentalCoroutinesApi::class)
+    val media = repository.getChats()
+        .map { chats ->
+            combine(
+                chats.map { chat ->
+                    createTimelineMediaItemList(chat)
+                },
+            ) { timelineMediaItems ->
+                timelineMediaItems.toList().flatten()
             }
-            newList.sortByDescending { it.timestamp }
-            media = newList
+        }
+        .flattenConcat()
+        .onEach { list ->
+            if (::preloadManager.isInitialized && list.isNotEmpty()) {
+                preloadManager.init(list)
+            }
+        }
+
+    private fun createTimelineMediaItemList(chatDetail: ChatDetail): Flow<List<TimelineMediaItem>> {
+        return repository.findMessages(chatDetail.chatWithLastMessage.id).map { messages ->
+            messages.filter {
+                it.mediaUri != null
+            }.map {
+                TimelineMediaItem(
+                    uri = it.mediaUri!!,
+                    type = if (it.mediaMimeType?.contains("video") == true) {
+                        TimelineMediaType.VIDEO
+                    } else {
+                        TimelineMediaType.PHOTO
+                    },
+                    timestamp = it.timestamp,
+                    chatName = chatDetail.firstContact.name,
+                    chatIconUri = chatDetail.firstContact.iconUri,
+                )
+            }
         }
     }
 
@@ -120,7 +132,12 @@ class TimelineViewModel @Inject constructor(
 
         // Reduced buffer durations since the primary use-case is for short-form videos
         val loadControl =
-            DefaultLoadControl.Builder().setBufferDurationsMs(5_000, 20_000, 5_00, DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS)
+            DefaultLoadControl.Builder().setBufferDurationsMs(
+                5_000,
+                20_000,
+                5_00,
+                DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS,
+            )
                 .setPrioritizeTimeOverSizeThresholds(true).build()
 
         playerThread.start()
@@ -156,11 +173,6 @@ class TimelineViewModel @Inject constructor(
                 application.applicationContext,
             )
         preloadManager.setPreloadWindowSize(5)
-
-        // Add videos to preload
-        if (media.isNotEmpty()) {
-            preloadManager.init(media)
-        }
     }
 
     fun releasePlayer() {

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/EmptyTimeline.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/EmptyTimeline.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.samples.socialite.ui.home.timeline.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.google.android.samples.socialite.R
+
+@Composable
+internal fun EmptyTimeline(
+    contentPadding: PaddingValues,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(contentPadding)
+            .padding(64.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.Companion.CenterHorizontally,
+    ) {
+        Image(
+            painter = painterResource(id = R.drawable.empty_timeline),
+            contentDescription = null,
+        )
+        Text(
+            text = stringResource(R.string.timeline_empty_title),
+            modifier = Modifier.Companion.padding(top = 64.dp),
+            style = MaterialTheme.typography.titleLarge,
+        )
+        Text(
+            text = stringResource(R.string.timeline_empty_message),
+            textAlign = TextAlign.Companion.Center,
+        )
+    }
+}

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/MetadataOverlay.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/MetadataOverlay.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.samples.socialite.ui.home.timeline.component
+
+import android.media.MediaMetadataRetriever
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.produceState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import androidx.core.net.toUri
+import com.google.android.samples.socialite.ui.home.timeline.TimelineMediaItem
+import com.google.android.samples.socialite.ui.home.timeline.TimelineMediaType
+import com.google.android.samples.socialite.ui.rememberIconPainter
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+@Composable
+internal fun MetadataOverlay(modifier: Modifier, mediaItem: TimelineMediaItem) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .zIndex(999f),
+    ) {
+        if (mediaItem.type == TimelineMediaType.VIDEO) {
+            val mediaMetadataRetriever = MediaMetadataRetriever()
+            val context = LocalContext.current.applicationContext
+
+            // Running on an IO thread for loading metadata from remote urls to reduce lag time
+            val duration: State<Long?> = produceState<Long?>(initialValue = null) {
+                withContext(Dispatchers.IO) {
+                    // Remote url
+                    if (mediaItem.uri.contains("https://")) {
+                        mediaMetadataRetriever.setDataSource(
+                            mediaItem.uri,
+                            HashMap<String, String>(),
+                        )
+                    } else { // Locally saved files
+                        mediaMetadataRetriever.setDataSource(context, mediaItem.uri.toUri())
+                    }
+                    value =
+                        mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                            ?.toLong()
+                }
+            }
+            duration.value?.let {
+                val seconds = it / 1000L
+                val minutes = seconds / 60L
+                Box(
+                    modifier = Modifier.Companion
+                        .padding(16.dp)
+                        .align(Alignment.Companion.TopEnd)
+                        .clip(RoundedCornerShape(50))
+                        .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)),
+                ) {
+                    Text(
+                        modifier = Modifier.Companion.padding(8.dp),
+                        text = "%d:%02d".format(minutes, seconds % 60),
+                    )
+                }
+            }
+        }
+
+        Row(
+            modifier = Modifier.Companion
+                .padding(16.dp)
+                .align(Alignment.Companion.BottomStart)
+                .clip(androidx.compose.foundation.shape.RoundedCornerShape(50))
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.Companion.CenterVertically,
+        ) {
+            mediaItem.chatIconUri?.let {
+                Image(
+                    painter = rememberIconPainter(contentUri = it),
+                    contentDescription = null,
+                    modifier = Modifier.Companion
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .background(Color.Companion.LightGray),
+                )
+            }
+            Text(modifier = Modifier.Companion.padding(end = 16.dp), text = mediaItem.chatName)
+        }
+    }
+}

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/TimelineCard.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/TimelineCard.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.samples.socialite.ui.home.timeline.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun TimelineCard(
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit = {},
+) {
+    Box(
+        modifier = Modifier.Companion
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.secondaryContainer)
+            .then(modifier),
+        content = content,
+    )
+}

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/TimelineFormat.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/TimelineFormat.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.samples.socialite.ui.home.timeline.component
+
+import androidx.compose.material3.adaptive.WindowAdaptiveInfo
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.runtime.Composable
+import androidx.window.core.layout.WindowSizeClass
+
+enum class TimelineFormat {
+    Pager,
+    Grid,
+}
+
+@Composable
+fun rememberTimelineFormat(
+    windowAdaptiveInfo: WindowAdaptiveInfo = currentWindowAdaptiveInfo(),
+): TimelineFormat {
+    val isAtLeastMedium = windowAdaptiveInfo
+        .windowSizeClass
+        .isWidthAtLeastBreakpoint(WindowSizeClass.Companion.WIDTH_DP_MEDIUM_LOWER_BOUND)
+
+    return if (isAtLeastMedium) {
+        TimelineFormat.Grid
+    } else {
+        TimelineFormat.Pager
+    }
+}

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/TimelineGrid.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/TimelineGrid.kt
@@ -1,0 +1,356 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.samples.socialite.ui.home.timeline.component
+
+import android.net.Uri
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.carousel.CarouselDefaults
+import androidx.compose.material3.carousel.HorizontalUncontainedCarousel
+import androidx.compose.material3.carousel.rememberCarouselState
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onPlaced
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
+import androidx.media3.common.Player
+import androidx.media3.ui.compose.PlayerSurface
+import androidx.media3.ui.compose.modifiers.resizeWithContentScale
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.google.android.samples.socialite.R
+import com.google.android.samples.socialite.ui.components.PlayArrowIcon
+import com.google.android.samples.socialite.ui.components.VideoPreview
+import com.google.android.samples.socialite.ui.home.timeline.TimelineMediaItem
+import com.google.android.samples.socialite.ui.home.timeline.TimelineMediaType
+
+private const val INVALID_MEDIA_ITEM_INDEX = -1
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TimelineGrid(
+    mediaItems: List<TimelineMediaItem>,
+    player: Player?,
+    modifier: Modifier = Modifier,
+    columns: GridCells = GridCells.Adaptive(minSize = 240.dp),
+    verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(16.dp),
+    horizontalArrangement: Arrangement.Horizontal = Arrangement.spacedBy(16.dp),
+    contentPadding: PaddingValues = PaddingValues(horizontal = 16.dp),
+    onChangePlayerItem: (uri: Uri?, page: Int) -> Unit = { uri: Uri?, i: Int -> },
+) {
+    var selectedMediaItemIndex by rememberSaveable { mutableIntStateOf(INVALID_MEDIA_ITEM_INDEX) }
+    val shouldShowCarousel = selectedMediaItemIndex != INVALID_MEDIA_ITEM_INDEX
+
+    var carouselWidth by remember { mutableStateOf(0.dp) }
+
+    TimelineFrame(
+        shouldShowModalContent = shouldShowCarousel,
+        onDismissRequest = {
+            selectedMediaItemIndex = INVALID_MEDIA_ITEM_INDEX
+        },
+        modalContent = {
+            MediaItemCarousel(
+                mediaItems = mediaItems,
+                player = player,
+                itemWidth = carouselWidth,
+                initialIndex = selectedMediaItemIndex,
+                onChangePlayerItem = onChangePlayerItem,
+                modifier = Modifier.safeDrawingPadding(),
+            )
+        },
+        closeCarousel = {
+            IconButton(
+                onClick = {
+                    selectedMediaItemIndex = INVALID_MEDIA_ITEM_INDEX
+                },
+            ) {
+                Icon(
+                    Icons.Default.Close,
+                    tint = Color.White,
+                    contentDescription = stringResource(R.string.close_carousel),
+                )
+            }
+        },
+        modifier = modifier.onPlaced {
+            carouselWidth = it.size.width.dp * 0.9f
+        },
+    ) {
+        LazyVerticalGrid(
+            columns = columns,
+            verticalArrangement = verticalArrangement,
+            horizontalArrangement = horizontalArrangement,
+            contentPadding = contentPadding,
+        ) {
+            itemsIndexed(mediaItems) { index, mediaItem ->
+                TimelineGridItem(
+                    mediaItem = mediaItem,
+                    modifier = Modifier.aspectRatio(0.7072f),
+                    onClick = {
+                        selectedMediaItemIndex = index
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelineFrame(
+    shouldShowModalContent: Boolean,
+    modifier: Modifier = Modifier,
+    scrimBrush: Brush = SolidColor(Color.Black.copy(alpha = 0.8f)),
+    onDismissRequest: () -> Unit = {},
+    modalContent: @Composable BoxScope.() -> Unit = {},
+    closeCarousel: @Composable () -> Unit = {},
+    content: @Composable BoxScope.() -> Unit,
+) {
+    Box(
+        modifier = modifier.clickable(onClick = onDismissRequest),
+    ) {
+        TimelineScaffold { contentPadding ->
+            Box(
+                modifier = Modifier.padding(contentPadding),
+            ) {
+                content()
+            }
+        }
+        AnimatedVisibility(
+            shouldShowModalContent,
+            enter = fadeIn(),
+            exit = fadeOut(),
+        ) {
+            Scrim(brush = scrimBrush, modifier = Modifier.fillMaxSize())
+            modalContent()
+            Box(
+                modifier = Modifier.padding(vertical = 48.dp, horizontal = 32.dp),
+            ) {
+                closeCarousel()
+            }
+        }
+    }
+}
+
+@Composable
+private fun Scrim(
+    modifier: Modifier = Modifier,
+    brush: Brush = SolidColor(Color.Black.copy(alpha = 0.8f)),
+) {
+    Box(
+        modifier = Modifier
+            .background(brush)
+            .then(modifier),
+    )
+}
+
+@Composable
+fun TimelineGridItem(
+    mediaItem: TimelineMediaItem,
+    modifier: Modifier = Modifier,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    onClick: () -> Unit = {},
+) {
+    TimelineCard(
+        modifier = modifier.clickable(
+            interactionSource = interactionSource,
+            indication = ripple(),
+            onClick = onClick,
+        ),
+    ) {
+        when (mediaItem.type) {
+            TimelineMediaType.PHOTO -> {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(mediaItem.uri)
+                        .build(),
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize(),
+                )
+            }
+
+            TimelineMediaType.VIDEO -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.colorScheme.primary),
+                ) {
+                    VideoPreview(
+                        videoUri = mediaItem.uri,
+                        contentScale = ContentScale.Crop,
+                    ) {
+                        PlayArrowIcon(
+                            modifier = Modifier.align(Alignment.Center),
+                        )
+                    }
+                }
+            }
+        }
+        MetadataOverlay(
+            mediaItem = mediaItem,
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun MediaItemCarousel(
+    mediaItems: List<TimelineMediaItem>,
+    itemWidth: Dp,
+    player: Player?,
+    onChangePlayerItem: (uri: Uri?, page: Int) -> Unit = { uri: Uri?, i: Int -> },
+    modifier: Modifier = Modifier,
+    initialIndex: Int = 0,
+) {
+    val carouselState = rememberCarouselState(initialItem = initialIndex) {
+        mediaItems.size
+    }
+
+    HorizontalUncontainedCarousel(
+        state = carouselState,
+        itemWidth = itemWidth,
+        itemSpacing = 8.dp,
+        contentPadding = PaddingValues(48.dp),
+        flingBehavior = CarouselDefaults.singleAdvanceFlingBehavior(state = carouselState),
+        modifier = modifier,
+    ) { index ->
+        val mediaItem = mediaItems[index]
+
+        when {
+            mediaItem.type == TimelineMediaType.PHOTO -> {
+                PhotoCarouselSlide(
+                    mediaItem = mediaItem,
+                )
+            }
+
+            mediaItem.type == TimelineMediaType.VIDEO && player != null -> {
+                VideoCarouselSlide(
+                    mediaItem = mediaItem,
+                    index = index,
+                    player = player,
+                    onChangePlayerItem = onChangePlayerItem,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PhotoCarouselSlide(
+    mediaItem: TimelineMediaItem,
+    modifier: Modifier = Modifier,
+) {
+    CarouselSlide(
+        mediaItem = mediaItem,
+        modifier = modifier,
+    ) {
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(mediaItem.uri)
+                .build(),
+            contentDescription = null,
+            contentScale = ContentScale.Fit,
+            modifier = modifier.fillMaxSize(),
+        )
+    }
+}
+
+@Composable
+private fun VideoCarouselSlide(
+    mediaItem: TimelineMediaItem,
+    index: Int,
+    player: Player,
+    modifier: Modifier = Modifier,
+    onChangePlayerItem: (uri: Uri?, page: Int) -> Unit = { uri: Uri?, i: Int -> },
+) {
+    val uri = mediaItem.uri.toUri()
+    DisposableEffect(uri) {
+        onChangePlayerItem(uri, index)
+        onDispose {
+            onChangePlayerItem(null, index)
+        }
+    }
+
+    CarouselSlide(
+        mediaItem = mediaItem,
+        modifier = modifier,
+    ) {
+        PlayerSurface(
+            player = player,
+            modifier = Modifier.resizeWithContentScale(
+                contentScale = ContentScale.Fit,
+                sourceSizeDp = null,
+            ),
+        )
+    }
+}
+
+@Composable
+private fun CarouselSlide(
+    mediaItem: TimelineMediaItem,
+    modifier: Modifier = Modifier,
+    contentAlignment: Alignment = Alignment.Center,
+    content: @Composable () -> Unit = {},
+) {
+    Box(
+        contentAlignment = contentAlignment,
+        modifier = modifier.fillMaxSize(),
+    ) {
+        content()
+        MetadataOverlay(
+            mediaItem = mediaItem,
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/TimelineScaffold.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/TimelineScaffold.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.samples.socialite.ui.home.timeline.component
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.google.android.samples.socialite.ui.home.HomeAppBar
+import com.google.android.samples.socialite.ui.home.HomeBackground
+import com.google.android.samples.socialite.ui.navigation.TopLevelDestination
+
+@Composable
+internal fun TimelineScaffold(
+    modifier: Modifier = Modifier,
+    topBar: @Composable () -> Unit = {
+        HomeAppBar(title = stringResource(TopLevelDestination.Timeline.label))
+    },
+    content: @Composable (contentPadding: PaddingValues) -> Unit = {},
+) {
+    Scaffold(
+        topBar = topBar,
+        modifier = modifier,
+    ) { contentPadding ->
+        HomeBackground(modifier = Modifier.Companion.fillMaxSize())
+        content(contentPadding)
+    }
+}

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/TimelineVerticalPager.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/TimelineVerticalPager.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.android.samples.socialite.ui.home.timeline.component
+
+import android.net.Uri
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.VerticalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
+import androidx.core.net.toUri
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.ui.compose.PlayerSurface
+import androidx.media3.ui.compose.modifiers.resizeWithContentScale
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.google.android.samples.socialite.ui.home.timeline.TimelineMediaItem
+import com.google.android.samples.socialite.ui.home.timeline.TimelineMediaType
+import kotlin.math.absoluteValue
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun TimelineVerticalPager(
+    mediaItems: List<TimelineMediaItem>,
+    player: Player?,
+    videoRatio: Float?,
+    modifier: Modifier = Modifier,
+    onChangePlayerItem: (uri: Uri?, page: Int) -> Unit = { uri: Uri?, i: Int -> },
+) {
+    val pagerState = rememberPagerState(pageCount = { mediaItems.count() })
+    LaunchedEffect(pagerState) {
+        // Collect from the a snapshotFlow reading the settledPage
+        snapshotFlow { pagerState.settledPage }.collect { page ->
+            if (mediaItems[page].type == TimelineMediaType.VIDEO) {
+                onChangePlayerItem(mediaItems[page].uri.toUri(), pagerState.currentPage)
+            } else {
+                onChangePlayerItem(null, pagerState.currentPage)
+            }
+        }
+    }
+
+    VerticalPager(
+        state = pagerState,
+        modifier = modifier,
+    ) { page ->
+        if (player != null) {
+            TimelineCard(
+                modifier = Modifier.Companion
+                    .fillMaxSize()
+                    .padding(8.dp)
+                    .graphicsLayer {
+                        // Calculate the absolute offset for the current page from the
+                        // scroll position. We use the absolute value which allows us to mirror
+                        // any effects for both directions
+                        val pageOffset = (
+                            (pagerState.currentPage - page) + pagerState
+                                .currentPageOffsetFraction
+                            ).absoluteValue
+
+                        // We animate the alpha, between 0% and 100%
+                        alpha = lerp(
+                            start = 0f,
+                            stop = 1f,
+                            fraction = 1f - pageOffset.coerceIn(0f, 1f),
+                        )
+                    },
+            ) {
+                TimelinePage(
+                    modifier = Modifier.Companion
+                        .align(Alignment.Companion.Center)
+                        .padding(8.dp)
+                        .clip(RoundedCornerShape(8.dp)),
+                    media = mediaItems[page],
+                    player = player,
+                    page,
+                    pagerState,
+                    videoRatio,
+                )
+
+                MetadataOverlay(
+                    modifier = Modifier.Companion.padding(16.dp),
+                    mediaItem = mediaItems[page],
+                )
+            }
+        }
+    }
+}
+
+@androidx.annotation.OptIn(UnstableApi::class)
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun TimelinePage(
+    modifier: Modifier = Modifier,
+    media: TimelineMediaItem,
+    player: Player,
+    page: Int,
+    state: PagerState,
+    videoRatio: Float?,
+) {
+    when (media.type) {
+        TimelineMediaType.VIDEO -> {
+            if (page == state.settledPage) {
+                when {
+                    // When in preview, place a Box with the received modifier preserving layout
+                    LocalInspectionMode.current -> {
+                        Box(modifier = modifier)
+                    }
+
+                    else -> {
+                        PlayerSurface(
+                            player = player,
+                            modifier = modifier.resizeWithContentScale(
+                                ContentScale.Companion.Fit,
+                                null,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+
+        TimelineMediaType.PHOTO -> {
+            AsyncImage(
+                model = ImageRequest.Builder(LocalContext.current)
+                    .data(media.uri)
+                    .build(),
+                contentDescription = null,
+                modifier = modifier
+                    .fillMaxSize(),
+                contentScale = ContentScale.Companion.Fit,
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,4 +81,7 @@
     <string name="page_up">Page up</string>
     <string name="page_down">Page down</string>
 
+    <!-- Timeline screen -->
+    <string name="close_carousel">Close carousel</string>
+
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,8 @@ benchmarkMacroJunit4 = "1.3.4"
 baselineprofile = "1.3.4"
 camera = "1.5.0-alpha06"
 coil = "2.7.0"
-compose_bom = "2025.04.00"
+compose = "1.9.0-alpha01"
+compose_bom = "2025.04.01"
 composeCompiler = "1.5.4" # Used in app/build.gradle.kts
 concurrent = "1.2.0"
 core = "1.16.0"
@@ -36,18 +37,18 @@ kotlinxSerializationJson = "1.8.1"
 ksp = "2.1.10-1.0.30"
 lifecycle = "2.8.7"
 android-material3 = "1.13.0-alpha13"
-material3 = "1.3.2"
+material3 = "1.4.0-alpha13"
 media3 = "1.6.1"
 navigation = "2.8.9"
 profileinstaller = "1.4.1"
-room = "2.7.0"
+room = "2.7.1"
 spotless = "7.0.2"
 test = "1.2.1"
 truth = "1.1.3"
 turbine = "1.0.0"
 uiautomator = "2.3.0"
 window = "1.3.0"
-material3-adaptive-navigation-suite = "1.4.0-alpha12"
+material3-adaptive-navigation-suite = "1.4.0-alpha13"
 glance = "1.1.1"
 secrets = "2.0.1"
 generativeai = "0.9.0"
@@ -76,8 +77,8 @@ compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = 
 compose-material-icons = { group = "androidx.compose.material", name = "material-icons-extended" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 compose-material3-adaptive = { group = "androidx.compose.material3", name = "material3-adaptive-navigation-suite", version.ref = "material3-adaptive-navigation-suite"}
-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
-compose-ui = { group = "androidx.compose.ui", name = "ui" }
+compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "compose" }
+compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
 compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 compose-ui-test = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 compose-ui-test-manisfest = { group = "androidx.compose.ui", name = "ui-test-manifest" }


### PR DESCRIPTION
This PR fixes a LS issue on the timeline screen. The items are self-letterboxed on medium+ width window and the media items in a grid. Users can show the entire photo and video by tapping the thumbnail displayed in the grid. 