### PR TITLE
Update navigation3 to latest snapshot

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,7 +37,7 @@ secrets {
 
 android {
     namespace = "com.google.android.samples.socialite"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.google.android.samples.socialite"
@@ -166,7 +166,8 @@ dependencies {
     implementation(libs.generativeai)
     implementation(libs.datastore)
 
-    implementation(libs.androidx.navigation3)
+    implementation(libs.androidx.navigation3.runtime)
+    implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.lifecycle.viewmodel.navigation3)
 }

--- a/app/src/main/java/com/google/android/samples/socialite/ui/Main.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/Main.kt
@@ -21,7 +21,6 @@ import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Text
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
-import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
@@ -30,8 +29,8 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
 import androidx.compose.ui.Modifier
-import androidx.navigation3.NavEntry
-import androidx.navigation3.SceneNavDisplay
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.ui.NavDisplay
 import com.google.android.samples.socialite.AppArgs
 import com.google.android.samples.socialite.tryCreateIntentFrom
 import com.google.android.samples.socialite.ui.camera.Camera
@@ -77,7 +76,7 @@ fun MainNavigation(
         modifier = modifier,
         backStack = backStack,
     ) {
-        SceneNavDisplay(
+        NavDisplay(
             backStack = backStack,
             onBack = { repeat(it) { backStack.removeLastOrNull() } },
             sceneStrategy = rememberListDetailSceneStrategy(
@@ -95,9 +94,7 @@ fun MainNavigation(
 
                     is Pane.ChatsList -> NavEntry(
                         key = backStackKey,
-                        metadata = ListDetailPaneScaffoldSceneStrategy.paneRole(
-                            ListDetailPaneScaffoldRole.List,
-                        ),
+                        metadata = ListDetailPaneScaffoldSceneStrategy.listPaneMetadata(),
                     ) {
                         ChatList(
                             onOpenChatRequest = { request ->
@@ -115,9 +112,7 @@ fun MainNavigation(
 
                     is Pane.ChatThread -> NavEntry(
                         key = backStackKey,
-                        metadata = ListDetailPaneScaffoldSceneStrategy.paneRole(
-                            ListDetailPaneScaffoldRole.Detail,
-                        ),
+                        metadata = ListDetailPaneScaffoldSceneStrategy.detailPaneMetadata(),
                     ) {
                         ChatScreen(
                             chatId = backStackKey.chatId,

--- a/app/src/main/java/com/google/android/samples/socialite/ui/navigation/ListDetailScene.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/navigation/ListDetailScene.kt
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2025 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TODO: Remove this when ListDetailSceneStrategy is merged into Material 3 Navigation 3
+
+@file:Suppress("ktlint")
+
+package com.google.android.samples.socialite.ui.navigation
+
+import androidx.activity.compose.PredictiveBackHandler
+import androidx.collection.IntList
+import androidx.collection.buildIntSet
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.Easing
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.layout.AnimatedPane
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldDefaults
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
+import androidx.compose.material3.adaptive.layout.MutableThreePaneScaffoldState
+import androidx.compose.material3.adaptive.layout.PaneAdaptedValue
+import androidx.compose.material3.adaptive.layout.PaneScaffoldDirective
+import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldDestinationItem
+import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldRole
+import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldScope
+import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldValue
+import androidx.compose.material3.adaptive.layout.calculateThreePaneScaffoldValue
+import androidx.compose.material3.adaptive.navigation.BackNavigationBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.ui.Scene
+import kotlinx.coroutines.CancellationException
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+internal class ListDetailPaneScaffoldScene<T : Any>(
+    override val key: Any,
+    val onBack: (Int) -> Unit,
+    val backNavBehavior: BackNavigationBehavior,
+    val directive: PaneScaffoldDirective,
+    /** All backstack entries, including those not relevant to the list-detail scaffold scene. */
+    val allEntries: List<NavEntry<T>>,
+    /** The entries in the backstack that are handled by this list-detail scaffold scene. */
+    val scaffoldEntries: List<NavEntry<T>>,
+    /** The indices of [allEntries] that result in [scaffoldEntries]. */
+    val scaffoldEntryIndices: IntList,
+    val detailPlaceholder: @Composable ThreePaneScaffoldScope.() -> Unit,
+) : Scene<T> {
+    override val entries: List<NavEntry<T>>
+        get() = scaffoldEntries
+
+    override val previousEntries: List<NavEntry<T>>
+        get() = onBackResult.previousEntries
+
+    private val entriesAsNavItems: List<ThreePaneScaffoldDestinationItem<T>> =
+        entries.map { it.toNavItem()!! }
+
+    class OnBackResult<T : Any>(
+        /**
+         * The previous scaffold value of the list-detail scaffold once a back event is handled.
+         *
+         * If this value is null, it means that either:
+         * - there is no previous NavEntry in the backstack, or
+         * - the back event leaves the list-detail scaffold scene and is therefore not handled
+         *   internally.
+         */
+        val previousScaffoldValue: ThreePaneScaffoldValue?,
+
+        /** The resulting backstack after the back event is handled. */
+        val previousEntries: List<NavEntry<T>>,
+    )
+
+    val onBackResult: OnBackResult<T> = calculateOnBackResult()
+
+    private fun calculateOnBackResult(): OnBackResult<T> {
+        // index relative to `scaffoldEntries`
+        val prevDestRelativeIndex = getPreviousDestinationIndex()
+
+        // index relative to `allEntries`
+        val prevDestAbsoluteIndex =
+            if (prevDestRelativeIndex < 0) {
+                scaffoldEntryIndices.first() - 1
+            } else {
+                scaffoldEntryIndices[prevDestRelativeIndex]
+            }
+
+        val scaffoldEntryIndicesSet = buildIntSet { scaffoldEntryIndices.forEach { add(it) } }
+
+        for (index in allEntries.lastIndex downTo 0) {
+            if (index !in scaffoldEntryIndicesSet) {
+                // Back event leaves the scaffold
+                return OnBackResult(
+                    previousScaffoldValue = null,
+                    previousEntries = allEntries.subList(0, index + 1).toList()
+                )
+            }
+            if (index == prevDestAbsoluteIndex) {
+                // Back event stays within the scaffold -- handled internally
+                val previousScaffoldValue =
+                    calculateScaffoldValue(
+                        destinationHistory = entriesAsNavItems.subList(0, prevDestRelativeIndex + 1)
+                    )
+                return OnBackResult(
+                    previousScaffoldValue = previousScaffoldValue,
+                    previousEntries = allEntries.subList(0, index + 1).toList()
+                )
+            }
+        }
+
+        // No previous entry in backstack
+        return OnBackResult(
+            previousScaffoldValue = null,
+            previousEntries = emptyList(),
+        )
+    }
+
+    private fun getPreviousDestinationIndex(): Int {
+        if (entriesAsNavItems.size <= 1) {
+            // No previous destination
+            return -1
+        }
+        val currentDestination = entriesAsNavItems.last()
+        val currentScaffoldValue: ThreePaneScaffoldValue =
+            calculateScaffoldValue(destinationHistory = entriesAsNavItems)
+
+        when (backNavBehavior) {
+            BackNavigationBehavior.PopLatest -> return entriesAsNavItems.lastIndex - 1
+            BackNavigationBehavior.PopUntilScaffoldValueChange ->
+                for (previousDestinationIndex in entriesAsNavItems.lastIndex - 1 downTo 0) {
+                    val previousValue =
+                        calculateScaffoldValue(
+                            destinationHistory =
+                                entriesAsNavItems.subList(0, previousDestinationIndex + 1),
+                        )
+                    if (previousValue != currentScaffoldValue) {
+                        return previousDestinationIndex
+                    }
+                }
+            BackNavigationBehavior.PopUntilCurrentDestinationChange ->
+                for (previousDestinationIndex in entriesAsNavItems.lastIndex - 1 downTo 0) {
+                    val destination = entriesAsNavItems[previousDestinationIndex].pane
+                    if (destination != currentDestination.pane) {
+                        return previousDestinationIndex
+                    }
+                }
+            BackNavigationBehavior.PopUntilContentChange ->
+                for (previousDestinationIndex in entriesAsNavItems.lastIndex - 1 downTo 0) {
+                    val contentKey = entriesAsNavItems[previousDestinationIndex].contentKey
+                    if (contentKey != currentDestination.contentKey) {
+                        return previousDestinationIndex
+                    }
+                    // A scaffold value change also counts as a content change.
+                    val previousValue =
+                        calculateScaffoldValue(
+                            destinationHistory =
+                                entriesAsNavItems.subList(0, previousDestinationIndex + 1),
+                        )
+                    if (previousValue != currentScaffoldValue) {
+                        return previousDestinationIndex
+                    }
+                }
+        }
+
+        return -1
+    }
+
+    private fun calculateScaffoldValue(
+        destinationHistory: List<ThreePaneScaffoldDestinationItem<*>>
+    ): ThreePaneScaffoldValue =
+        calculateThreePaneScaffoldValue(
+            maxHorizontalPartitions = directive.maxHorizontalPartitions,
+            maxVerticalPartitions = directive.maxVerticalPartitions,
+            adaptStrategies = ListDetailPaneScaffoldDefaults.adaptStrategies(),
+            destinationHistory = destinationHistory,
+        )
+
+    override val content: @Composable () -> Unit = {
+        val scaffoldValue = calculateScaffoldValue(destinationHistory = entriesAsNavItems)
+        val scaffoldState = remember { MutableThreePaneScaffoldState(scaffoldValue) }
+        LaunchedEffect(scaffoldValue) { scaffoldState.animateTo(scaffoldValue) }
+
+        val previousScaffoldValue = onBackResult.previousScaffoldValue
+        PredictiveBackHandler(enabled = previousScaffoldValue != null) { progress ->
+            try {
+                progress.collect { backEvent ->
+                    scaffoldState.seekTo(
+                        fraction =
+                            backProgressToStateProgress(
+                                progress = backEvent.progress,
+                                scaffoldValue = scaffoldValue,
+                            ),
+                        targetState = previousScaffoldValue!!,
+                    )
+                }
+                onBack(allEntries.size - onBackResult.previousEntries.size)
+            } catch (_: CancellationException) {
+                scaffoldState.animateTo(targetState = scaffoldValue)
+            }
+        }
+
+        val lastList = entries.findLast { it.paneRole == ListDetailPaneScaffoldRole.List }
+        val lastDetail = entries.findLast { it.paneRole == ListDetailPaneScaffoldRole.Detail }
+        val lastExtra = entries.findLast { it.paneRole == ListDetailPaneScaffoldRole.Extra }
+
+        ListDetailPaneScaffold(
+            directive = directive,
+            scaffoldState = scaffoldState,
+            listPane =
+                lastList?.content?.let { { AnimatedPane { it.invoke(lastList.key) } } } ?: {},
+            detailPane =
+                lastDetail?.content?.let { { AnimatedPane { it.invoke(lastDetail.key) } } }
+                    ?: detailPlaceholder,
+            extraPane = lastExtra?.content?.let { { AnimatedPane { it.invoke(lastExtra.key) } } },
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private val <T : Any> NavEntry<T>.paneRole: ThreePaneScaffoldRole?
+    get() {
+        val metadata =
+            this.metadata[ListDetailPaneScaffoldSceneStrategy.Companion.ListDetailRoleKey]
+                as? ListDetailPaneScaffoldSceneStrategy.PaneMetadata ?: return null
+        return when (metadata) {
+            is ListDetailPaneScaffoldSceneStrategy.ListMetadata -> ListDetailPaneScaffoldRole.List
+            is ListDetailPaneScaffoldSceneStrategy.DetailMetadata ->
+                ListDetailPaneScaffoldRole.Detail
+            is ListDetailPaneScaffoldSceneStrategy.ExtraMetadata -> ListDetailPaneScaffoldRole.Extra
+        }
+    }
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private fun <T : Any> NavEntry<T>.toNavItem(): ThreePaneScaffoldDestinationItem<T>? {
+    val role = this.paneRole ?: return null
+    return ThreePaneScaffoldDestinationItem(
+        pane = role,
+        contentKey = this.key,
+    )
+}
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private fun backProgressToStateProgress(
+    progress: Float,
+    scaffoldValue: ThreePaneScaffoldValue,
+): Float =
+    ThreePaneScaffoldPredictiveBackEasing.transform(progress) *
+        when (scaffoldValue.expandedCount) {
+            1 -> SinglePaneProgressRatio
+            2 -> DualPaneProgressRatio
+            else -> TriplePaneProgressRatio
+        }
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private val ThreePaneScaffoldValue.expandedCount: Int
+    get() {
+        var count = 0
+        if (primary == PaneAdaptedValue.Expanded) {
+            count++
+        }
+        if (secondary == PaneAdaptedValue.Expanded) {
+            count++
+        }
+        if (tertiary == PaneAdaptedValue.Expanded) {
+            count++
+        }
+        return count
+    }
+
+private val ThreePaneScaffoldPredictiveBackEasing: Easing = CubicBezierEasing(0.1f, 0.1f, 0f, 1f)
+private const val SinglePaneProgressRatio: Float = 0.1f
+private const val DualPaneProgressRatio: Float = 0.15f
+private const val TriplePaneProgressRatio: Float = 0.2f

--- a/app/src/main/java/com/google/android/samples/socialite/ui/navigation/ListDetailSceneStrategy.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/navigation/ListDetailSceneStrategy.kt
@@ -14,40 +14,27 @@
  * limitations under the License.
  */
 
-// TODO: Remove this when ListDetailSceneStrategy is merged into Navigation 3
+// TODO: Remove this when ListDetailSceneStrategy is merged into Material 3 Navigation 3
 
+@file:Suppress("ktlint")
 @file:OptIn(ExperimentalMaterial3AdaptiveApi::class)
 
 package com.google.android.samples.socialite.ui.navigation
 
-import androidx.activity.compose.PredictiveBackHandler
-import androidx.compose.animation.core.CubicBezierEasing
-import androidx.compose.animation.core.Easing
-import androidx.compose.material3.Text
+import androidx.collection.mutableIntListOf
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
-import androidx.compose.material3.adaptive.layout.AnimatedPane
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffold
-import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldDefaults
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
-import androidx.compose.material3.adaptive.layout.MutableThreePaneScaffoldState
-import androidx.compose.material3.adaptive.layout.PaneAdaptedValue
 import androidx.compose.material3.adaptive.layout.PaneScaffoldDirective
-import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldDestinationItem
-import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldRole
 import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldScope
-import androidx.compose.material3.adaptive.layout.ThreePaneScaffoldValue
 import androidx.compose.material3.adaptive.layout.calculatePaneScaffoldDirective
-import androidx.compose.material3.adaptive.layout.calculateThreePaneScaffoldValue
 import androidx.compose.material3.adaptive.navigation.BackNavigationBehavior
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.navigation3.NavEntry
-import androidx.navigation3.Scene
-import androidx.navigation3.SceneStrategy
-import androidx.navigation3.SceneStrategyResult
-import kotlinx.coroutines.CancellationException
+import androidx.navigation3.runtime.NavEntry
+import androidx.navigation3.ui.Scene
+import androidx.navigation3.ui.SceneStrategy
 
 /**
  * Creates and remembers a [ListDetailPaneScaffoldSceneStrategy].
@@ -75,13 +62,13 @@ fun <T : Any> rememberListDetailSceneStrategy(
         )
     }
 }
-
 /**
  * A [ListDetailPaneScaffoldSceneStrategy] supports arranging [NavEntry]s into an adaptive
- * [ListDetailPaneScaffold]. By using [paneRole] in a NavEntry's metadata, entries can be assigned
- * as belonging to a list pane, detail pane, or extra pane. These panes will be displayed together
- * if the window size is sufficiently large, and will automatically adapt if the window size
- * changes, for example, on a foldable device.
+ * [ListDetailPaneScaffold]. By using [listPaneMetadata], [detailPaneMetadata], or
+ * [extraPaneMetadata] in a NavEntry's metadata, entries can be assigned as belonging to a list
+ * pane, detail pane, or extra pane. These panes will be displayed together if the window size is
+ * sufficiently large, and will automatically adapt if the window size changes, for example, on a
+ * foldable device.
  *
  * @param onBack a callback for handling system back press. The passed [Int] refers to the number of
  *   entries to pop from the end of the backstack, as calculated by the
@@ -97,283 +84,79 @@ class ListDetailPaneScaffoldSceneStrategy<T : Any>(
     val directive: PaneScaffoldDirective,
 ) : SceneStrategy<T> {
     @Composable
-    override fun calculateScene(entries: List<NavEntry<T>>): SceneStrategyResult<T>? {
+    override fun calculateScene(entries: List<NavEntry<T>>): Scene<T>? {
         if (entries.last().metadata[ListDetailRoleKey] == null) return null
-
+        val sceneKey = (entries.last().metadata[ListDetailRoleKey] as PaneMetadata).sceneKey
         val scaffoldEntries = mutableListOf<NavEntry<T>>()
-        val scaffoldEntryIndices = mutableListOf<Int>()
-
+        val scaffoldEntryIndices = mutableIntListOf()
+        var detailPlaceholder: (@Composable ThreePaneScaffoldScope.() -> Unit)? = null
         for ((index, entry) in entries.withIndex()) {
-            if (entry.metadata[ListDetailRoleKey] is ThreePaneScaffoldRole) {
+            val metadata = entry.metadata[ListDetailRoleKey] as? PaneMetadata
+            if (metadata != null && metadata.sceneKey == sceneKey) {
                 scaffoldEntryIndices.add(index)
                 scaffoldEntries.add(entry)
+                if (metadata is ListMetadata) {
+                    detailPlaceholder = metadata.detailPlaceholder
+                }
             }
         }
-
         if (scaffoldEntries.isEmpty()) return null
-
         val scene =
             ListDetailPaneScaffoldScene(
-                key = scaffoldEntries.first().key,
+                key = sceneKey,
                 onBack = onBack,
                 backNavBehavior = backNavigationBehavior,
                 directive = directive,
                 allEntries = entries,
                 scaffoldEntries = scaffoldEntries,
                 scaffoldEntryIndices = scaffoldEntryIndices,
-                // TODO: bubble this up in the API
-                detailPlaceholder = { Text("Detail Placeholder") },
+                detailPlaceholder = detailPlaceholder ?: {},
             )
-
-        return SceneStrategyResult(
-            scene = scene,
-            previousEntries = scene.onBackResult.previousEntries,
-        )
+        return scene
     }
-
+    internal sealed interface PaneMetadata {
+        val sceneKey: Any
+    }
+    internal class ListMetadata(
+        override val sceneKey: Any = Unit,
+        val detailPlaceholder: @Composable ThreePaneScaffoldScope.() -> Unit = {}
+    ) : PaneMetadata
+    internal class DetailMetadata(override val sceneKey: Any = Unit) : PaneMetadata
+    internal class ExtraMetadata(override val sceneKey: Any = Unit) : PaneMetadata
     companion object {
         internal val ListDetailRoleKey: String = ListDetailPaneScaffoldRole::class.qualifiedName!!
-
-        fun paneRole(role: ThreePaneScaffoldRole) = mapOf(ListDetailRoleKey to role)
-    }
-}
-
-internal class ListDetailPaneScaffoldScene<T : Any>(
-    override val key: T,
-    val onBack: (Int) -> Unit,
-    val backNavBehavior: BackNavigationBehavior,
-    val directive: PaneScaffoldDirective,
-    /** All backstack entries, including those not relevant to the list-detail scaffold scene. */
-    val allEntries: List<NavEntry<T>>,
-    /** The entries in the backstack that are handled by this list-detail scaffold scene. */
-    val scaffoldEntries: List<NavEntry<T>>,
-    /** The indices of [allEntries] that result in [scaffoldEntries]. */
-    val scaffoldEntryIndices: List<Int>,
-    val detailPlaceholder: @Composable ThreePaneScaffoldScope.() -> Unit,
-) : Scene<T> {
-    override val entries: List<NavEntry<T>>
-        get() = scaffoldEntries
-
-    private val entriesAsNavItems: List<ThreePaneScaffoldDestinationItem<T>> =
-        entries.map { it.toNavItem()!! }
-
-    class OnBackResult<T : Any>(
         /**
-         * The previous scaffold value of the list-detail scaffold once a back event is handled.
+         * Constructs metadata to mark a [NavEntry] as belonging to a
+         * [list pane][ListDetailPaneScaffoldRole.List] within a [ListDetailPaneScaffold].
          *
-         * If this value is null, it means that either:
-         * - there is no previous NavEntry in the backstack, or
-         * - the back event leaves the list-detail scaffold scene and is therefore not handled
-         *   internally.
+         * @param sceneKey the key to distinguish the scene of the list-detail scaffold, in case
+         *   multiple list-detail scaffolds are supported within the same NavDisplay.
+         * @param detailPlaceholder composable content to display in the detail pane in case there
+         *   is no other [NavEntry] representing a detail pane in the backstack. Note that this
+         *   content does not receive the same scoping mechanisms as a full-fledged [NavEntry].
          */
-        val previousScaffoldValue: ThreePaneScaffoldValue?,
-
-        /** The resulting backstack after the back event is handled. */
-        val previousEntries: List<NavEntry<T>>,
-    )
-
-    val onBackResult: OnBackResult<T> = calculateOnBackResult()
-
-    private fun calculateOnBackResult(): OnBackResult<T> {
-        // index relative to `scaffoldEntries`
-        val prevDestRelativeIndex = getPreviousDestinationIndex()
-
-        // index relative to `allEntries`
-        val prevDestAbsoluteIndex =
-            if (prevDestRelativeIndex < 0) {
-                scaffoldEntryIndices.first() - 1
-            } else {
-                scaffoldEntryIndices[prevDestRelativeIndex]
-            }
-
-        val scaffoldEntryIndicesSet = scaffoldEntryIndices.toSet()
-
-        for (index in allEntries.lastIndex downTo 0) {
-            if (index !in scaffoldEntryIndicesSet) {
-                // Back event leaves the scaffold
-                return OnBackResult(
-                    previousScaffoldValue = null,
-                    previousEntries = allEntries.subList(0, index + 1).toList(),
-                )
-            }
-            if (index == prevDestAbsoluteIndex) {
-                // Back event stays within the scaffold -- handled internally
-                val previousScaffoldValue =
-                    calculateScaffoldValue(
-                        destinationHistory = entriesAsNavItems.subList(0, prevDestRelativeIndex + 1),
-                    )
-                return OnBackResult(
-                    previousScaffoldValue = previousScaffoldValue,
-                    previousEntries = allEntries.subList(0, index + 1).toList(),
-                )
-            }
-        }
-
-        // No previous entry in backstack
-        return OnBackResult(
-            previousScaffoldValue = null,
-            previousEntries = emptyList(),
-        )
-    }
-
-    private fun getPreviousDestinationIndex(): Int {
-        if (entriesAsNavItems.size <= 1) {
-            // No previous destination
-            return -1
-        }
-        val currentDestination = entriesAsNavItems.last()
-        val currentScaffoldValue: ThreePaneScaffoldValue =
-            calculateScaffoldValue(destinationHistory = entriesAsNavItems)
-
-        when (backNavBehavior) {
-            BackNavigationBehavior.PopLatest -> return entriesAsNavItems.lastIndex - 1
-            BackNavigationBehavior.PopUntilScaffoldValueChange ->
-                for (previousDestinationIndex in entriesAsNavItems.lastIndex - 1 downTo 0) {
-                    val previousValue =
-                        calculateScaffoldValue(
-                            destinationHistory =
-                            entriesAsNavItems.subList(0, previousDestinationIndex + 1),
-                        )
-                    if (previousValue != currentScaffoldValue) {
-                        return previousDestinationIndex
-                    }
-                }
-            BackNavigationBehavior.PopUntilCurrentDestinationChange ->
-                for (previousDestinationIndex in entriesAsNavItems.lastIndex - 1 downTo 0) {
-                    val destination = entriesAsNavItems[previousDestinationIndex].pane
-                    if (destination != currentDestination.pane) {
-                        return previousDestinationIndex
-                    }
-                }
-            BackNavigationBehavior.PopUntilContentChange ->
-                for (previousDestinationIndex in entriesAsNavItems.lastIndex - 1 downTo 0) {
-                    val contentKey = entriesAsNavItems[previousDestinationIndex].contentKey
-                    if (contentKey != currentDestination.contentKey) {
-                        return previousDestinationIndex
-                    }
-                    // A scaffold value change also counts as a content change.
-                    val previousValue =
-                        calculateScaffoldValue(
-                            destinationHistory =
-                            entriesAsNavItems.subList(0, previousDestinationIndex + 1),
-                        )
-                    if (previousValue != currentScaffoldValue) {
-                        return previousDestinationIndex
-                    }
-                }
-        }
-
-        return -1
-    }
-
-    private fun calculateScaffoldValue(
-        destinationHistory: List<ThreePaneScaffoldDestinationItem<*>>,
-    ): ThreePaneScaffoldValue =
-        calculateThreePaneScaffoldValue(
-            maxHorizontalPartitions = directive.maxHorizontalPartitions,
-            /*maxVerticalPartitions = directive.maxVerticalPartitions,*/
-            adaptStrategies = ListDetailPaneScaffoldDefaults.adaptStrategies(),
-            destinationHistory = destinationHistory,
-        )
-
-    override val content: @Composable () -> Unit = {
-        val scaffoldValue = calculateScaffoldValue(destinationHistory = entriesAsNavItems)
-        val scaffoldState = remember { MutableThreePaneScaffoldState(scaffoldValue) }
-        LaunchedEffect(scaffoldValue) { scaffoldState.animateTo(scaffoldValue) }
-
-        val previousScaffoldValue = onBackResult.previousScaffoldValue
-        PredictiveBackHandler(enabled = previousScaffoldValue != null) { progress ->
-            try {
-                progress.collect { backEvent ->
-                    scaffoldState.seekTo(
-                        fraction =
-                        backProgressToStateProgress(
-                            progress = backEvent.progress,
-                            scaffoldValue = scaffoldValue,
-                        ),
-                        targetState = previousScaffoldValue!!,
-                    )
-                }
-                onBack(allEntries.size - onBackResult.previousEntries.size)
-            } catch (_: CancellationException) {
-                scaffoldState.animateTo(targetState = scaffoldValue)
-            }
-        }
-
-        val lastList =
-            entries.findLast {
-                it.metadata[ListDetailPaneScaffoldSceneStrategy.ListDetailRoleKey] ==
-                    ListDetailPaneScaffoldRole.List
-            }
-        val lastDetail =
-            entries.findLast {
-                it.metadata[ListDetailPaneScaffoldSceneStrategy.ListDetailRoleKey] ==
-                    ListDetailPaneScaffoldRole.Detail
-            }
-        val lastExtra =
-            entries.findLast {
-                it.metadata[ListDetailPaneScaffoldSceneStrategy.ListDetailRoleKey] ==
-                    ListDetailPaneScaffoldRole.Extra
-            }
-
-        ListDetailPaneScaffold(
-            directive = directive,
-            scaffoldState = scaffoldState,
-            listPane =
-            lastList?.content?.let {
-                {
-                    // TODO: allow customizing AnimatedPane params
-                    AnimatedPane { it.invoke(lastList.key) }
-                }
-            } ?: {},
-            detailPane =
-            lastDetail?.content?.let { { AnimatedPane { it.invoke(lastDetail.key) } } }
-                ?: detailPlaceholder,
-            extraPane = lastExtra?.content?.let { { AnimatedPane { it.invoke(lastExtra.key) } } },
-            // TODO: drag handle/pane expansion state
-        )
+        fun listPaneMetadata(
+            sceneKey: Any = Unit,
+            detailPlaceholder: @Composable ThreePaneScaffoldScope.() -> Unit = {}
+        ): Map<String, Any> = mapOf(ListDetailRoleKey to ListMetadata(sceneKey, detailPlaceholder))
+        /**
+         * Constructs metadata to mark a [NavEntry] as belonging to a
+         * [detail pane][ListDetailPaneScaffoldRole.Detail] within a [ListDetailPaneScaffold].
+         *
+         * @param sceneKey the key to distinguish the scene of the list-detail scaffold, in case
+         *   multiple list-detail scaffolds are supported within the same NavDisplay.
+         */
+        fun detailPaneMetadata(sceneKey: Any = Unit): Map<String, Any> =
+            mapOf(ListDetailRoleKey to DetailMetadata(sceneKey))
+        /**
+         * Constructs metadata to mark a [NavEntry] as belonging to an
+         * [extra pane][ListDetailPaneScaffoldRole.Extra] within a [ListDetailPaneScaffold].
+         *
+         * @param sceneKey the key to distinguish the scene of the list-detail scaffold, in case
+         *   multiple list-detail scaffolds are supported within the same NavDisplay.
+         */
+        fun extraPaneMetadata(sceneKey: Any = Unit): Map<String, Any> =
+            mapOf(ListDetailRoleKey to ExtraMetadata(sceneKey))
     }
 }
 
-private fun <T : Any> NavEntry<T>.toNavItem(): ThreePaneScaffoldDestinationItem<T>? {
-    val role =
-        this.metadata[ListDetailPaneScaffoldSceneStrategy.ListDetailRoleKey]
-            as? ThreePaneScaffoldRole ?: return null
-    return ThreePaneScaffoldDestinationItem(
-        pane = role,
-        contentKey = this.key,
-    )
-}
-
-@OptIn(ExperimentalMaterial3AdaptiveApi::class)
-private fun backProgressToStateProgress(
-    progress: Float,
-    scaffoldValue: ThreePaneScaffoldValue,
-): Float =
-    THREE_PANE_SCAFFOLD_PREDICTIVE_BACK_EASING.transform(progress) *
-        when (scaffoldValue.expandedCount) {
-            1 -> SINGLE_PANE_PROGRESS_RATIO
-            2 -> DUAL_PANE_PROGRESS_RATIO
-            else -> TRIPLE_PANE_PROGRESS_RATIO
-        }
-
-@OptIn(ExperimentalMaterial3AdaptiveApi::class)
-private val ThreePaneScaffoldValue.expandedCount: Int
-    get() {
-        var count = 0
-        if (primary == PaneAdaptedValue.Expanded) {
-            count++
-        }
-        if (secondary == PaneAdaptedValue.Expanded) {
-            count++
-        }
-        if (tertiary == PaneAdaptedValue.Expanded) {
-            count++
-        }
-        return count
-    }
-
-private val THREE_PANE_SCAFFOLD_PREDICTIVE_BACK_EASING: Easing = CubicBezierEasing(0.1f, 0.1f, 0f, 1f)
-private const val SINGLE_PANE_PROGRESS_RATIO: Float = 0.1f
-private const val DUAL_PANE_PROGRESS_RATIO: Float = 0.15f
-private const val TRIPLE_PANE_PROGRESS_RATIO: Float = 0.2f

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,7 +125,8 @@ generativeai = { group = "com.google.ai.client.generativeai", name = "generative
 datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore"}
 androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodel" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleViewmodel" }
-androidx-navigation3 = { module = "androidx.navigation3:navigation3", version.ref = "navigation3" }
+androidx-navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
+androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,7 @@ pluginManagement {
         gradlePluginPortal()
         maven {
             // Currently need to use a snapshot build to get Navigation 3 library
-            url = uri("https://androidx.dev/snapshots/builds/13409917/artifacts/repository")
+            url = uri("https://androidx.dev/snapshots/builds/13467503/artifacts/repository")
         }
     }
 }
@@ -33,7 +33,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven {
-            url = uri("https://androidx.dev/snapshots/builds/13409917/artifacts/repository")
+            url = uri("https://androidx.dev/snapshots/builds/13467503/artifacts/repository")
         }
     }
 }


### PR DESCRIPTION
Updates to use the latest snapshot of navigation3, which moves a couple things around. This also uses the latest prototype from the WIP integration with material3-adaptive.