### PR TITLE
Fixing navigation back to the chat screen after video editing.

### DIFF
--- a/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreen.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreen.kt
@@ -86,6 +86,7 @@ import androidx.media3.ui.PlayerView
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.google.android.samples.socialite.R
+import com.google.android.samples.socialite.ui.navigation.Route
 
 /**
  * Configuration options for video preview.
@@ -117,7 +118,7 @@ fun VideoEditScreen(
 
     val isFinishedEditing = viewModel.isFinishedEditing.collectAsStateWithLifecycle()
     if (isFinishedEditing.value) {
-        navController.popBackStack("chat/$chatId", false)
+        navController.popBackStack(Route.ChatThread(chatId), false)
     }
 
     val isProcessing = viewModel.isProcessing.collectAsState()


### PR DESCRIPTION
The transition from the Video Edit screen back to the Chat screen was left off from this previous change: https://github.com/android/socialite/commit/f4028b794b7624f6e9fa614c84765975711319a0