### PR TITLE
Add Cast support for short-form content

### DIFF
--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <option name="previewPanelProviderInfo">
+      <ProviderInfo name="Compose (experimental)" className="com.intellij.markdown.compose.preview.ComposePanelProvider" />
+    </option>
+  </component>
+</project>

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Socialite includes the following third-party software/code:
+
+NanoHTTPD
+Copyright (c) 2012-2013 by Paul S. Hawke, 2001, 2005-2013 by Jarno Elonen, 2010 by Konstantinos Togias
+License: Modified BSD License (see licenses/NANOHTTPD_LICENSE)

--- a/README.md
+++ b/README.md
@@ -107,3 +107,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+---
+**Third-Party Licenses**
+
+SociaLite includes the [NanoHTTPD](https://github.com/NanoHttpd/nanohttpd) library, which is licensed under a Modified BSD License. See the [NOTICE](NOTICE) file for more details.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -43,7 +43,7 @@ android {
 
     defaultConfig {
         applicationId = "com.google.android.samples.socialite"
-        minSdk = 21
+        minSdk = 23
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
@@ -166,6 +166,8 @@ dependencies {
     implementation(libs.media3.transformer)
     implementation(libs.media3.ui)
     implementation(libs.media3.ui.compose)
+    implementation(libs.media3.cast)
+    implementation(libs.nanohttpd)
 
     implementation(libs.hilt.android)
     implementation(libs.hilt.navigation.compose)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,12 @@
         android:theme="@style/Theme.Social"
         tools:targetApi="34">
 
+        <meta-data
+            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="androidx.media3.cast.DefaultCastOptionsProvider" />
+
+        <receiver android:name="androidx.mediarouter.media.MediaTransferReceiver" />
+
         <receiver
             android:name=".widget.SociaLiteAppWidgetReceiver"
             android:exported="true"

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/Timeline.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/Timeline.kt
@@ -49,6 +49,7 @@ fun Timeline(
 
     val player = viewModel.player
     val videoRatio = viewModel.videoRatio
+    val isRemote = viewModel.isRemote
 
     when {
         mediaItems.isEmpty() -> {
@@ -62,6 +63,7 @@ fun Timeline(
                 player = player,
                 mediaItems = mediaItems,
                 videoRatio = videoRatio,
+                isRemote = isRemote,
                 onChangePlayerItem = viewModel::changePlayerItem,
                 onInitializePlayer = viewModel::initializePlayer,
                 onReleasePlayer = viewModel::releasePlayer,
@@ -77,6 +79,7 @@ fun Timeline(
     mediaItems: List<TimelineMediaItem>,
     player: Player?,
     videoRatio: Float?,
+    isRemote: Boolean,
     modifier: Modifier = Modifier,
     format: TimelineFormat = rememberTimelineFormat(),
     onChangePlayerItem: (uri: Uri?, page: Int) -> Unit = { uri: Uri?, i: Int -> },
@@ -109,6 +112,7 @@ fun Timeline(
                     mediaItems = mediaItems,
                     player = player,
                     videoRatio = videoRatio,
+                    isRemote = isRemote,
                     onChangePlayerItem = onChangePlayerItem,
                     modifier = Modifier
                         .fillMaxSize()

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/TimelineViewModel.kt
@@ -73,7 +73,6 @@ class TimelineViewModel @Inject constructor(
     // Keeps track if the current playback location is remote or local
     var isRemote by mutableStateOf(false)
 
-
     // Width/Height ratio of the current media item, used to properly size the Surface
     var videoRatio by mutableStateOf<Float?>(null)
 

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/TimelineViewModel.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/TimelineViewModel.kt
@@ -16,6 +16,7 @@
 
 package com.google.android.samples.socialite.ui.home.timeline
 
+import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
 import android.os.HandlerThread
@@ -26,7 +27,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.media3.cast.CastPlayer
 import androidx.media3.common.C
+import androidx.media3.common.DeviceInfo
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
@@ -36,25 +40,39 @@ import androidx.media3.exoplayer.ExoPlayer
 import com.google.android.samples.socialite.model.ChatDetail
 import com.google.android.samples.socialite.repository.ChatRepository
 import com.google.android.samples.socialite.ui.player.preloadmanager.PreloadManagerWrapper
+import com.google.android.samples.socialite.utils.LocalMediaServer
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.IOException
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flattenConcat
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+private const val TAG = "TimelineViewModel"
 
 @UnstableApi
 @HiltViewModel
 class TimelineViewModel @Inject constructor(
     @ApplicationContext private val application: Context,
     private val repository: ChatRepository,
+    private val localMediaServer: LocalMediaServer,
 ) : ViewModel() {
     // Single player instance - in the future, we can implement a pool of players to improve
     // latency and allow for concurrent playback
-    var player by mutableStateOf<ExoPlayer?>(null)
+    var player by mutableStateOf<Player?>(null)
+
+    // Cast player instance
+    var castPlayer by mutableStateOf<CastPlayer?>(null)
+
+    // Keeps track if the current playback location is remote or local
+    var isRemote by mutableStateOf(false)
+
 
     // Width/Height ratio of the current media item, used to properly size the Surface
     var videoRatio by mutableStateOf<Float?>(null)
@@ -67,6 +85,26 @@ class TimelineViewModel @Inject constructor(
     private var playerThread: HandlerThread? = null
 
     var playbackStartTimeMs = C.TIME_UNSET
+
+    private var currentVideoUri: Uri? = null
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                localMediaServer.start()
+            } catch (e: IOException) {
+                Log.e(TAG, "Failed to start local media server", e)
+            }
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        viewModelScope.launch(Dispatchers.IO) {
+            localMediaServer.stop()
+        }
+        releasePlayer()
+    }
 
     private val videoSizeListener = object : Player.Listener {
         override fun onVideoSizeChanged(videoSize: VideoSize) {
@@ -85,6 +123,53 @@ class TimelineViewModel @Inject constructor(
             Log.d("PreloadManager", "\t\tTime to first Frame = $timeToFirstFrameMs ")
             super.onRenderedFirstFrame()
         }
+    }
+
+    /**
+     * Listens for MediaRoute connection events.
+     * When a Cast device connects or disconnects, this listener seamlessly transfers
+     * the currently playing video to the new playback destination.
+     */
+    private val castPlayerListener = object : Player.Listener {
+        override fun onDeviceInfoChanged(deviceInfo: DeviceInfo) {
+            isRemote = deviceInfo.playbackType == DeviceInfo.PLAYBACK_TYPE_REMOTE
+            currentVideoUri?.let { uri ->
+                val mediaItem = getMediaItemForUri(uri)
+                val typeStr = if (isRemote) "REMOTE" else "LOCAL"
+                Log.i(TAG, "Serving content on $typeStr: ${mediaItem.localConfiguration?.uri}")
+                player?.apply {
+                    setMediaItem(mediaItem)
+                    prepare()
+                    play()
+                }
+            }
+        }
+    }
+
+    /**
+     * Determines the appropriate [MediaItem] source structure for a given URI.
+     *
+     * If the session is casting to a remote device AND the URI points to a local file
+     * (content:// or file://), the Cast receiver cannot securely access that file path.
+     * To solve this, we proxy the file stream over an HTTP URL backed by our own [LocalMediaServer].
+     *
+     * @param uri The original location of the file to play.
+     * @return A [MediaItem] that ExoPlayer/CastPlayer can natively decode.
+     */
+    private fun getMediaItemForUri(uri: Uri): MediaItem {
+        val isLocal = uri.scheme in listOf(
+            ContentResolver.SCHEME_FILE,
+            ContentResolver.SCHEME_CONTENT,
+        ) || uri.path.orEmpty().startsWith("/storage/")
+        if (!isRemote || !isLocal) return MediaItem.fromUri(uri)
+
+        val ip = localMediaServer.getLocalIpAddress() ?: return MediaItem.fromUri(uri)
+        val port = localMediaServer.listeningPort.takeIf { it > 0 } ?: return MediaItem.fromUri(uri)
+
+        val proxyPath = if (uri.scheme == ContentResolver.SCHEME_CONTENT) "/$uri" else uri.path
+        localMediaServer.currentSharedUri = proxyPath?.removePrefix("/")
+
+        return MediaItem.fromUri("http://$ip:$port$proxyPath")
     }
 
     @kotlin.OptIn(ExperimentalCoroutinesApi::class)
@@ -151,9 +236,12 @@ class TimelineViewModel @Inject constructor(
                 it.addListener(videoSizeListener)
                 it.addListener(firstFrameListener)
             }
+        castPlayer =
+            CastPlayer.Builder(application.applicationContext).setLocalPlayer(newPlayer).build()
+        castPlayer?.addListener(castPlayerListener)
 
         videoRatio = null
-        player = newPlayer
+        player = castPlayer
 
         if (enablePreloadManager) {
             initPreloadManager(loadControl, thread)
@@ -185,6 +273,8 @@ class TimelineViewModel @Inject constructor(
         if (enablePreloadManager) {
             preloadManager.release()
         }
+        castPlayer?.removeListener(castPlayerListener)
+        castPlayer?.release()
         player?.apply {
             removeListener(videoSizeListener)
             removeListener(firstFrameListener)
@@ -203,18 +293,19 @@ class TimelineViewModel @Inject constructor(
             stop()
             videoRatio = null
             if (uri != null) {
+                currentVideoUri = uri
                 // Set the right source to play
-                val mediaItem = MediaItem.fromUri(uri)
+                val mediaItem = getMediaItemForUri(uri)
+                Log.d(TAG, "Media item changed: ${mediaItem.localConfiguration?.uri}")
 
                 if (enablePreloadManager) {
                     val mediaSource = preloadManager.getMediaSource(mediaItem)
                     Log.d("PreloadManager", "Mediasource $mediaSource ")
 
-                    if (mediaSource == null) {
-                        setMediaItem(mediaItem)
-                    } else {
-                        // Use the preloaded media source
+                    if (!isRemote && mediaSource != null && this is ExoPlayer) {
                         setMediaSource(mediaSource)
+                    } else {
+                        setMediaItem(mediaItem)
                     }
                     preloadManager.setCurrentPlayingIndex(currentPlayingIndex)
                 } else {

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/TimelineVerticalPager.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/component/TimelineVerticalPager.kt
@@ -232,6 +232,8 @@ private fun MediaItem(
     }
 }
 
+private val MediaRouteButtonIntrinsicPadding = 15.dp
+
 @Composable
 private fun PlayerControls(
     uri: String,
@@ -241,7 +243,7 @@ private fun PlayerControls(
     Row(
         modifier = modifier.padding(8.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy((-15).dp),
+        horizontalArrangement = Arrangement.spacedBy(-MediaRouteButtonIntrinsicPadding),
     ) {
         // Display an info button to inspect the video's metadata.
         IconButton(

--- a/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreen.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreen.kt
@@ -555,7 +555,7 @@ private fun VideoMessagePreview(
         modifier = Modifier
             .width(250.dp)
             .height(450.dp),
-        )
+    )
 
     LaunchedEffect(previewConfig) {
         // Release the previous player instance if it exists

--- a/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreenViewModel.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreenViewModel.kt
@@ -31,8 +31,8 @@ import androidx.annotation.OptIn
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.media3.common.C.TRACK_TYPE_VIDEO
 import androidx.media3.common.C.TRACK_TYPE_AUDIO
+import androidx.media3.common.C.TRACK_TYPE_VIDEO
 import androidx.media3.common.Effect
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes

--- a/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreenViewModel.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/videoedit/VideoEditScreenViewModel.kt
@@ -31,6 +31,8 @@ import androidx.annotation.OptIn
 import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.media3.common.C.TRACK_TYPE_VIDEO
+import androidx.media3.common.C.TRACK_TYPE_AUDIO
 import androidx.media3.common.Effect
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
@@ -208,7 +210,9 @@ class VideoEditScreenViewModel @Inject constructor(
         val editedMediaItem =
             EditedMediaItem.Builder(mediaItem)
                 .setRemoveAudio(removeAudio).setDurationUs(durationUs).build()
-        val videoImageSequence = EditedMediaItemSequence(editedMediaItem)
+        val videoImageSequence =
+            EditedMediaItemSequence.Builder(mutableSetOf(TRACK_TYPE_VIDEO, TRACK_TYPE_AUDIO))
+                .addItem(editedMediaItem).build()
 
         val compositionBuilder = Composition.Builder(videoImageSequence)
         // Tone-map to SDR if style transfer is selected since it can only be applied for SDR videos

--- a/app/src/main/java/com/google/android/samples/socialite/utils/LocalMediaServer.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/utils/LocalMediaServer.kt
@@ -1,0 +1,112 @@
+package com.google.android.samples.socialite.utils
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import android.webkit.MimeTypeMap
+import dagger.hilt.android.qualifiers.ApplicationContext
+import fi.iki.elonen.NanoHTTPD
+import java.io.File
+import java.net.Inet4Address
+import java.net.NetworkInterface
+import java.net.SocketException
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val TAG = "LocalMediaServer"
+
+/**
+ * Serves local media (content:// or file://) to the Google Cast receiver.
+ * The Cast receiver operates as a web app and cannot read Android device paths securely.
+ * This local proxy streams bytes seamlessly over HTTP to the receiver.
+ */
+@Singleton
+class LocalMediaServer @Inject constructor(
+    @ApplicationContext private val context: Context
+) : NanoHTTPD(0) {
+
+    /**
+     * The single URI that is currently authorized to be streamed.
+     * Prevents arbitrary path traversal and unauthorized data access on the local network.
+     */
+    @Volatile
+    var currentSharedUri: String? = null
+
+    /**
+     * Handles incoming HTTP requests from the Cast receiver.
+     *
+     * Verifies the requested URI matches the authorized [currentSharedUri], then
+     * seamlessly resolves the local file or content stream and chunks it over HTTP.
+     *
+     * @param session The inbound HTTP request session.
+     * @return The HTTP response containing the chunked media stream or an error status.
+     */
+    override fun serve(session: IHTTPSession): Response {
+        val uriString = session.uri.substringAfter("/")
+        Log.d(TAG, "Request: $uriString")
+
+        if (uriString != currentSharedUri) {
+            Log.w(TAG, "Blocked unauthorized request: $uriString")
+            return newFixedLengthResponse(Response.Status.FORBIDDEN, MIME_PLAINTEXT, "Forbidden")
+        }
+
+        return try {
+            val isContentUri = uriString.startsWith("${ContentResolver.SCHEME_CONTENT}://")
+            val androidUri = if (isContentUri) Uri.parse(uriString) else null
+
+            val inputStream = if (isContentUri) {
+                androidUri?.let { context.contentResolver.openInputStream(it) }
+            } else {
+                File(uriString).takeIf { it.isFile }?.inputStream()
+            }
+
+            if (inputStream != null) {
+                val mime = if (isContentUri) {
+                    androidUri?.let { context.contentResolver.getType(it) } ?: getMimeType(uriString)
+                } else {
+                    getMimeType(uriString)
+                }
+                newChunkedResponse(Response.Status.OK, mime, inputStream)
+            } else {
+                Log.w(TAG, "Content not found: $uriString")
+                newFixedLengthResponse(Response.Status.NOT_FOUND, MIME_PLAINTEXT, "Content not found")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error serving file", e)
+            newFixedLengthResponse(Response.Status.INTERNAL_ERROR, MIME_PLAINTEXT, "Internal Error")
+        }
+    }
+
+    /**
+     * Determines the most appropriate local IPv4 address of the device to bind the HTTP server.
+     * Filters out loopbacks, virtual interfaces, and inactive connections.
+     *
+     * @return The local IPv4 address as a string, or null if no valid address is found.
+     */
+    fun getLocalIpAddress(): String? {
+        return try {
+            NetworkInterface.getNetworkInterfaces().asSequence()
+                .filter { !it.isLoopback && it.isUp && !it.isVirtual }
+                .flatMap { it.inetAddresses.asSequence() }
+                .firstOrNull { !it.isLoopbackAddress && it is Inet4Address }
+                ?.hostAddress
+        } catch (ex: SocketException) {
+            Log.e(TAG, "Error getting IP address", ex)
+            null
+        }
+    }
+
+    companion object {
+        /**
+         * Infers the MIME type of a file based on its extension using the native Android [MimeTypeMap].
+         *
+         * @param url The file path or URI string.
+         * @return The inferred MIME type (e.g. "video/mp4"), defaulting to "text/plain".
+         */
+        private fun getMimeType(url: String): String {
+            val extension = MimeTypeMap.getFileExtensionFromUrl(url)
+            return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension) ?: MIME_PLAINTEXT
+        }
+    }
+}

--- a/app/src/main/java/com/google/android/samples/socialite/utils/LocalMediaServer.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/utils/LocalMediaServer.kt
@@ -23,7 +23,7 @@ private const val TAG = "LocalMediaServer"
  */
 @Singleton
 class LocalMediaServer @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
 ) : NanoHTTPD(0) {
 
     /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,7 @@ android-material3 = "1.13.0-alpha13"
 material3 = "1.4.0-alpha15"
 material3-adaptive-navigation-suite = "1.4.0-alpha15"
 material3-adaptive-navigation3 = "1.0.0-SNAPSHOT"
-media3 = "1.8.0"
+media3 = "1.9.0"
 media3-ui-compose = "1.7.1"
 navigation3 = "1.0.0-alpha01"
 profileinstaller = "1.4.1"
@@ -126,6 +126,8 @@ media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", versi
 media3-transformer = { group = "androidx.media3", name = "media3-transformer", version.ref = "media3" }
 media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "media3" }
 media3-ui-compose = { group = "androidx.media3", name = "media3-ui-compose", version.ref = "media3-ui-compose" }
+media3-cast = { group = "androidx.media3", name = "media3-cast", version.ref = "media3" }
+nanohttpd = { group = "org.nanohttpd", name = "nanohttpd", version = "2.3.1" }
 navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
 navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
 profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }

--- a/licenses/NANOHTTPD_LICENSE
+++ b/licenses/NANOHTTPD_LICENSE
@@ -1,0 +1,11 @@
+Copyright (c) 2012-2013 by Paul S. Hawke, 2001,2005-2013 by Jarno Elonen, 2010 by Konstantinos Togias All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+Neither the name of the NanoHttpd organization nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
This PR introduces **Cast** support to the Socialite **Timeline**, allowing users to cast short-form videos directly to Cast-enabled devices.

[Link to Screen recording](https://drive.google.com/file/d/1FtA30P97r1qiXZV1cdtcviUfWZBrg4gO/view?resourcekey=0-Alr11fOhZPRmXD0lpjEAQQ)

**Key Changes:**

- **Dependencies:** Bumped AndroidX Media3 to `1.9.0` to enable the latest `CastPlayer` features.
- **Timeline Cast Support:** Added `CastPlayer` into the `Timeline`  to seamlessly hand over playback between local and remote Cast device.
- **Local Media Proxy:** Google Cast receivers apps cannot natively read Android file paths. This PR implements a dynamic, secure HTTP server (`LocalMediaServer`) that safely proxies local media (`content://` and `file://`) to the remote Cast device.