### PR TITLE
Use same version for Media3 and Media3 Compose dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,12 +161,14 @@ dependencies {
     implementation(libs.camera.view)
 
     implementation(libs.media3.common)
+    implementation(libs.media3.cast)
     implementation(libs.media3.effect)
     implementation(libs.media3.exoplayer)
+    implementation(libs.media3.inspector)
     implementation(libs.media3.transformer)
     implementation(libs.media3.ui)
     implementation(libs.media3.ui.compose)
-    implementation(libs.media3.cast)
+    // For local server hosting required by Media3 Cast
     implementation(libs.nanohttpd)
 
     implementation(libs.hilt.android)

--- a/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/README.md
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/home/timeline/README.md
@@ -1,9 +1,17 @@
 # Timeline Module
 
-This directory contains the code for the timeline screen of the SociaLite application. This screen displays a vertical feed of all photos and videos shared across all chat threads. This screen uses `PreloadManagerWrapper.kt` which builds on ExoPlayer's [DefaultPreloadManager](https://developer.android.com/reference/androidx/media3/exoplayer/source/preload/DefaultPreloadManager) to enable smooth vertical scrolling between media items.
+This directory contains the code for the timeline screen of the SociaLite application. This screen displays a vertical feed of all photos and videos shared across all chat threads.
 
--   **Timeline UI:** Jetpack Compose composables (e.g., `TimelineScreen.kt`) for displaying the list of media items (photos and videos) in a scrollable feed. This involves displaying the media content and potentially some associated information like the sender or timestamp.
--   **ViewModel Logic:** A ViewModel (e.g., `TimelineViewModel`) to manage the state and logic for the timeline screen. This ViewModel is responsible for fetching the list of media items from the data layer and exposing it to the UI.
--   **Integration with Data Layer:** Code within the ViewModel to interact with the data layer (specifically the repositories) to retrieve all shared media content from the database.
+## Features
+
+- **Preload Manager:** Uses `PreloadManagerWrapper.kt` which builds on ExoPlayer's [DefaultPreloadManager](https://developer.android.com/reference/androidx/media3/exoplayer/source/preload/DefaultPreloadManager) to enable smooth vertical scrolling between media items.
+- **Media Inspector:** Shows an "i" icon at the top left of media items. Clicking it inspects the media using the [Media3 Inspector](https://developer.android.com/media/media3/inspector) module.
+- **Google Cast:** Beside the inspector icon, shows a cast button. Clicking it allows casting the content to a Cast-enabled device using the [Media3 Cast](https://developer.android.com/media/media3/cast) module.
+
+## Architecture
+
+- **Timeline UI:** Jetpack Compose composables (e.g., `TimelineScreen.kt`) for displaying the list of media items (photos and videos) in a scrollable feed. This involves displaying the media content and potentially some associated information like the sender or timestamp.
+- **ViewModel Logic:** A ViewModel (e.g., `TimelineViewModel`) to manage the state and logic for the timeline screen. This ViewModel is responsible for fetching the list of media items from the data layer and exposing it to the UI.
+- **Integration with Data Layer:** Code within the ViewModel to interact with the data layer (specifically the repositories) to retrieve all shared media content from the database.
 
 This module demonstrates how to display a collection of media items fetched from a local data source.

--- a/app/src/main/java/com/google/android/samples/socialite/ui/metadata/MetadataProcessor.kt
+++ b/app/src/main/java/com/google/android/samples/socialite/ui/metadata/MetadataProcessor.kt
@@ -24,8 +24,8 @@ import androidx.media3.common.Format
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.MediaExtractorCompat
-import androidx.media3.exoplayer.MetadataRetriever
+import androidx.media3.inspector.MediaExtractorCompat
+import androidx.media3.inspector.MetadataRetriever
 import java.nio.ByteBuffer
 import java.util.Locale
 import kotlin.math.roundToInt

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,6 @@ material3 = "1.4.0-alpha15"
 material3-adaptive-navigation-suite = "1.4.0-alpha15"
 material3-adaptive-navigation3 = "1.0.0-SNAPSHOT"
 media3 = "1.9.0"
-media3-ui-compose = "1.7.1"
 navigation3 = "1.0.0-alpha01"
 profileinstaller = "1.4.1"
 room = "2.7.1"
@@ -120,13 +119,14 @@ lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewm
 litert = { group = "com.google.ai.edge.litert", name = "litert", version.ref = "litert" }
 litert-gpu = { group = "com.google.ai.edge.litert", name = "litert-gpu", version.ref = "litert" }
 litert-support-api = { group = "com.google.ai.edge.litert", name = "litert-support-api", version.ref = "litert" }
+media3-cast = { group = "androidx.media3", name = "media3-cast", version.ref = "media3" }
 media3-common = { group = "androidx.media3", name = "media3-common", version.ref = "media3" }
 media3-effect = { group = "androidx.media3", name = "media3-effect", version.ref = "media3" }
 media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
+media3-inspector = { group = "androidx.media3", name = "media3-inspector", version.ref = "media3" }
 media3-transformer = { group = "androidx.media3", name = "media3-transformer", version.ref = "media3" }
 media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "media3" }
-media3-ui-compose = { group = "androidx.media3", name = "media3-ui-compose", version.ref = "media3-ui-compose" }
-media3-cast = { group = "androidx.media3", name = "media3-cast", version.ref = "media3" }
+media3-ui-compose = { group = "androidx.media3", name = "media3-ui-compose", version.ref = "media3" }
 nanohttpd = { group = "org.nanohttpd", name = "nanohttpd", version = "2.3.1" }
 navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
 navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }


### PR DESCRIPTION
Use the same version (`1.9.0`) for both **Media3** and **Media3 Compose** dependencies.

**Minor changes:**
- Use `Inspector` module instead of `ExoPlayer` (since those APIs migrated from ExoPlayer to Inspector module).
- Reorder the dependencies alphabetically.
- Update the README to show features in the timeline for Cast and Inspector.